### PR TITLE
AG-48 Add new tests (no skill)

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,148 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfBrandIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingBrandId = Guid.NewGuid();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypeIds();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingBrandModel",
+            nonExistingBrandId,
+            type.Id,
+            2020,
+            2025,
+            [engineType],
+            [transmissionType],
+            [drivetrainType],
+            [bodyType]
+        );
+
+        // Act & Assert
+        await AssertCreateRequestFailsWithoutPersistence(commandRequest,
+            "no new VehicleModel should be persisted when BrandId does not exist");
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var nonExistingTypeId = Guid.NewGuid();
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypeIds();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingTypeModel",
+            brand.Id,
+            nonExistingTypeId,
+            2020,
+            2025,
+            [engineType],
+            [transmissionType],
+            [drivetrainType],
+            [bodyType]
+        );
+
+        // Act & Assert
+        await AssertCreateRequestFailsWithoutPersistence(commandRequest,
+            "no new VehicleModel should be persisted when TypeId does not exist");
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfNameAlreadyExistsForBrand()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>()
+            .Include(m => m.Brand)
+            .FirstAsync();
+
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypeIds();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            existingModel.Name,
+            existingModel.Brand.Id,
+            existingModel.TypeId,
+            2020,
+            2025,
+            [engineType],
+            [transmissionType],
+            [drivetrainType],
+            [bodyType]
+        );
+
+        // Act & Assert
+        await AssertCreateRequestFailsWithoutPersistence(commandRequest,
+            "no new VehicleModel should be persisted when name already exists for the brand");
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var updatedModel = await GetUpdatedModel();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var originalEngineTypeIds = updatedModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            updatedModel.Id,
+            updatedModel.MaximumProductionYear,
+            originalEngineTypeIds.Append(nonExistingEngineTypeId),
+            updatedModel.AvailableTransmissionTypes.Select(t => t.Id),
+            updatedModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            updatedModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var modelAfterUpdate = await GetUpdatedModel();
+
+        // Assert
+        response.IsSuccess
+            .Should().BeFalse();
+        response.Error
+            .Should().NotBe(Error.None);
+        modelAfterUpdate.AvailableEngineTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds,
+                "engine types should not be modified when update fails due to non-existing EngineTypeId");
+    }
+
+    private async Task<(Guid EngineType, Guid TransmissionType, Guid DrivetrainType, Guid BodyType)> GetVehicleTypeIds()
+    {
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+
+        return (engineType.Id, transmissionType.Id, drivetrainType.Id, bodyType.Id);
+    }
+
+    private async Task AssertCreateRequestFailsWithoutPersistence(
+        CreateVehicleModelCommandRequest commandRequest,
+        string reason)
+    {
+        var modelCountBefore = await Context.Set<VehicleModel>().CountAsync();
+
+        var response = await Sender.Send(commandRequest);
+        var modelCountAfter = await Context.Set<VehicleModel>().CountAsync();
+
+        response.IsSuccess
+            .Should().BeFalse();
+        response.Error
+            .Should().NotBe(Error.None);
+        modelCountAfter
+            .Should().Be(modelCountBefore, reason);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(


### PR DESCRIPTION
Implementation of AG-48

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Understand existing test patterns in VehicleModelCommandsIntegrationTests.cs
- Identify validation rules from Create/Update validators that need edge case coverage
- Design 3+ tests covering suggested scenarios using seeded reference data
- Ensure tests are deterministic, independent, and verify both Result state and persisted state
- Follow existing naming conventions and code style

## Overview

Add at least 3 meaningful integration tests to VehicleModelCommandsIntegrationTests.cs that validate edge cases for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Tests will verify validation failures for non-existing brand/type IDs, duplicate model names, and non-existing related type IDs during updates.

## Assumptions and Rules from CLAUDE.md

- No CLAUDE.md found; follow task-specified rules: no mocks, no in-memory DB, use existing infrastructure
- Reuse seeded data from SeedBrands, SeedModels, SeedVehicleTypes, etc.
- Follow existing test naming: `Send_XxxRequest_Should_YyyIfZzz`
- Use FluentAssertions with fluent method chaining style
- Verify `response.IsSuccess`, `response.Error`, and persisted state where relevant

## Step-by-Step Implementation

1. Add test: Create with non-existing BrandId should fail
- Use `Guid.NewGuid()` for BrandId with valid TypeId and type collections
- Verify `IsSuccess = false`, no VehicleModel persisted

2. Add test: Create with duplicate model name should fail
- Query existing model name (e.g., "Camry") from seeded data
- Attempt to create with same name
- Verify failure with `AlreadyExistingNameValue` error

3. Add test: Update with non-existing EngineTypeId should fail
- Get valid model, construct update request with fake engine type ID
- Verify failure, no partial relationship changes

4. Optional: Add test for Create with non-existing TypeId

## Error Handling and Uncertainties

- Ensure test isolation: each test uses unique data or verifies no side effects
- If validation checks name uniqueness globally vs per-brand, test should reflect actual behavior