### PR TITLE
AG-50 Vehicle model command coverage(no skill)

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,157 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfBrandIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistentBrandId = Guid.NewGuid();
+        var (type, engineType, bodyType, drivetrainType, transmissionType) = await GetVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "TestModel",
+            nonExistentBrandId,
+            type.Id,
+            2000,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var nonExistentTypeId = Guid.NewGuid();
+        var (_, engineType, bodyType, drivetrainType, transmissionType) = await GetVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "TestModel",
+            brand.Id,
+            nonExistentTypeId,
+            2000,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var nonExistentEngineTypeId = Guid.NewGuid();
+        var (_, _, bodyType, drivetrainType, transmissionType) = await GetVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "TestModel",
+            brand.Id,
+            type.Id,
+            2000,
+            2010,
+            [nonExistentEngineTypeId],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfModelIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistentModelId = Guid.NewGuid();
+        var (_, engineType, bodyType, drivetrainType, transmissionType) = await GetVehicleTypes();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            nonExistentModelId,
+            2015,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var updatedModel = await GetUpdatedModel();
+        var nonExistentEngineTypeId = Guid.NewGuid();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            updatedModel.Id,
+            updatedModel.MinimalProductionYear + 1,
+            updatedModel.AvailableEngineTypes.Select(t => t.Id).Append(nonExistentEngineTypeId),
+            updatedModel.AvailableTransmissionTypes.Select(t => t.Id),
+            updatedModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            updatedModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    private static void AssertFailureResponse(Result<Guid> response)
+    {
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+    }
+
+    private async Task<(VehicleType Type, VehicleEngineType EngineType, VehicleBodyType BodyType, VehicleDrivetrainType DrivetrainType, VehicleTransmissionType TransmissionType)> GetVehicleTypes()
+    {
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        return (type, engineType, bodyType, drivetrainType, transmissionType);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(


### PR DESCRIPTION
Implementation of AG-50

Improve the integration test coverage for vehicle model write operations.

The current coverage is not sufficient for the kinds of edge cases that can happen when creating or updating vehicle models with related vehicle metadata. Add a small but meaningful set of tests that would help prevent regressions in this area.

Keep the implementation consistent with the existing test style in the repository. Avoid overengineering and avoid changing production code unless the tests reveal a real issue.

# Implementation Plan

## Conceptual Checklist

1. Review existing test patterns and conventions in the codebase
2. Identify untested edge cases in Create and Update operations
3. Prioritize tests that cover related vehicle metadata scenarios
4. Implement tests following existing naming and structure conventions
5. Verify tests are consistent with the existing AAA pattern
6. Ensure no production code changes unless tests reveal actual bugs

## Overview

Add a focused set of integration tests for VehicleModel write operations covering edge cases with related vehicle metadata (engine types, body types, drivetrain types, transmission types) and validation scenarios not currently tested.

## Assumptions and Rules from CLAUDE.md

- Follow existing test naming: `Send_Request__`
- Use xUnit `[Fact]` attributes for tests
- Follow AAA (Arrange-Act-Assert) pattern with comment headers
- Use FluentAssertions for assertions
- Leverage `IntegrationTestBase` for `Sender`, `Context`, and `Faker`
- Keep tests focused and not overengineered

## Step-by-Step Implementation

1. Add Create tests for edge cases:
- Test with non-existent BrandId returns failure
- Test with non-existent TypeId returns failure
- Test with non-existent metadata IDs (e.g., engine type) returns failure
- Test with duplicate model name returns failure
- Dependencies: Existing test infrastructure
- Files: `VehicleModelCommandsIntegrationTests.cs`

2. Add Update tests for edge cases:
- Test update with non-existent model ID returns NotFound
- Test update with non-existent metadata IDs returns failure
- Dependencies: Step 1 completion
- Files: `VehicleModelCommandsIntegrationTests.cs`

3. Verify all tests run successfully and follow conventions

## Error Handling and Uncertainties

- If the database seeding doesn't include enough variety of metadata types, tests may need to create test data first
- Ensure Testcontainers setup provides sufficient isolation between tests