### PR TITLE
AG-52 Reference data command consistency(no skill)

### DIFF
--- a/tests/ApplicationUnitTests/VehicleColors/CollectionVehicleColorsQueryRequestHandlerTests.cs
+++ b/tests/ApplicationUnitTests/VehicleColors/CollectionVehicleColorsQueryRequestHandlerTests.cs
@@ -56,4 +56,189 @@ public sealed class CollectionVehicleColorsQueryRequestHandlerTests
             .Should()
             .BeEquivalentTo(expectedResult);
     }
+
+    [Fact]
+    public async Task Handler_ShouldReturnEmptyCollection_WhenNoColorsExist()
+    {
+        // Arrange
+        List<VehicleColorDto> emptyColors = [];
+
+        var expectedResult = new PaginationResult<VehicleColorDto>(
+            emptyColors,
+            _request.FilteringParameters.PageIndex);
+
+        _vehicleColorService.GetVehicleColorCollection(_request, default)
+            .Returns(emptyColors);
+
+        // Act
+        var result = await _handler.Handle(_request, default);
+
+        // Assert
+        result.IsSuccess
+            .Should().BeTrue();
+
+        result.Value
+            .Should()
+            .BeEquivalentTo(expectedResult);
+
+        result.Value!.Items
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handler_ShouldReturnSingleColor_WhenOnlyOneColorExists()
+    {
+        // Arrange
+        List<VehicleColorDto> singleColor =
+        [
+            new VehicleColorDto("#0000FF") { Id = Guid.NewGuid(), Name = "Синій" }
+        ];
+
+        var expectedResult = new PaginationResult<VehicleColorDto>(
+            singleColor,
+            _request.FilteringParameters.PageIndex);
+
+        _vehicleColorService.GetVehicleColorCollection(_request, default)
+            .Returns(singleColor);
+
+        // Act
+        var result = await _handler.Handle(_request, default);
+
+        // Assert
+        result.IsSuccess
+            .Should().BeTrue();
+
+        result.Value!.Items
+            .Should()
+            .HaveCount(1);
+
+        result.Value.Items.First().Name
+            .Should()
+            .Be("Синій");
+    }
+
+    [Fact]
+    public async Task Handler_ShouldPassCorrectFilteringParameters_ToService()
+    {
+        // Arrange
+        var customFilteringParams = new VehicleColorFilteringRequestParameters
+        {
+            PageIndex = 2,
+            PageSize = 10
+        };
+        var customRequest = new CollectionVehicleColorsQueryRequest(customFilteringParams);
+
+        _vehicleColorService.GetVehicleColorCollection(customRequest, default)
+            .Returns([]);
+
+        // Act
+        await _handler.Handle(customRequest, default);
+
+        // Assert
+        await _vehicleColorService
+            .Received()
+            .GetVehicleColorCollection(
+                Arg.Is<CollectionVehicleColorsQueryRequest>(r =>
+                    r.FilteringParameters.PageIndex == 2 &&
+                    r.FilteringParameters.PageSize == 10),
+                default!);
+    }
+
+    [Fact]
+    public async Task Handler_ShouldReturnSuccessResult_WithCorrectPageIndex()
+    {
+        // Arrange
+        var customFilteringParams = new VehicleColorFilteringRequestParameters
+        {
+            PageIndex = 3
+        };
+        var customRequest = new CollectionVehicleColorsQueryRequest(customFilteringParams);
+
+        List<VehicleColorDto> colors =
+        [
+            new VehicleColorDto("#FFFFFF") { Id = Guid.NewGuid(), Name = "Білий" }
+        ];
+
+        _vehicleColorService.GetVehicleColorCollection(customRequest, default)
+            .Returns(colors);
+
+        // Act
+        var result = await _handler.Handle(customRequest, default);
+
+        // Assert
+        result.IsSuccess
+            .Should().BeTrue();
+
+        result.Value!.PageIndex
+            .Should()
+            .Be(3);
+    }
+
+    [Fact]
+    public async Task Handler_ShouldHandleLargeCollections_Correctly()
+    {
+        // Arrange
+        var largeColorCollection = Enumerable.Range(1, 100)
+            .Select(i => new VehicleColorDto($"#{i % 10:D2}{i % 10:D1}0000")
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Колір {i}"
+            })
+            .ToList();
+
+        _vehicleColorService.GetVehicleColorCollection(_request, default)
+            .Returns(largeColorCollection);
+
+        // Act
+        var result = await _handler.Handle(_request, default);
+
+        // Assert
+        result.IsSuccess
+            .Should().BeTrue();
+
+        result.Value!.Items
+            .Should()
+            .HaveCount(100);
+
+        result.Value.Items
+            .Should()
+            .BeEquivalentTo(largeColorCollection);
+    }
+
+    [Fact]
+    public async Task Handler_ShouldPreserveColorProperties_InResult()
+    {
+        // Arrange
+        var specificColor = new VehicleColorDto("#FF5733")
+        {
+            Id = Guid.Parse("12345678-1234-1234-1234-123456789abc"),
+            Name = "Помаранчевий"
+        };
+
+        List<VehicleColorDto> colors = [specificColor];
+
+        _vehicleColorService.GetVehicleColorCollection(_request, default)
+            .Returns(colors);
+
+        // Act
+        var result = await _handler.Handle(_request, default);
+
+        // Assert
+        result.IsSuccess
+            .Should().BeTrue();
+
+        var returnedColor = result.Value!.Items.First();
+        returnedColor.Id
+            .Should()
+            .Be(Guid.Parse("12345678-1234-1234-1234-123456789abc"));
+
+        returnedColor.Name
+            .Should()
+            .Be("Помаранчевий");
+
+        returnedColor.HexValue
+            .Should()
+            .Be("#FF5733");
+    }
 }

--- a/tests/IntegrationTests/VehicleColors/VehicleColorQueriesIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleColors/VehicleColorQueriesIntegrationTests.cs
@@ -4,6 +4,8 @@ using LanosCertifiedStore.Application.Shared.RequestParamsRelated;
 using LanosCertifiedStore.Application.Shared.ResultRelated;
 using LanosCertifiedStore.Application.VehicleColors;
 using LanosCertifiedStore.Application.VehicleColors.Queries.CollectionVehicleColorsQueryRequestRelated;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using Microsoft.EntityFrameworkCore;
 
 namespace IntegrationTests.VehicleColors;
 
@@ -32,9 +34,177 @@ public sealed class VehicleColorQueriesIntegrationTests(
         response.IsSuccess.Should().BeTrue();
 
         colors
-            .Should().BeInAscendingOrder(b => b.Name, 
+            .Should().BeInAscendingOrder(b => b.Name,
                 StringComparer.Create(new CultureInfo("uk-UA"), ignoreCase: true));
         colors.Count
             .Should().BeLessOrEqualTo((int)ItemQuantitySelection.Ten);
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_WithDescendingSorting_Should_ReturnColorsInDescendingOrder()
+    {
+        // Arrange
+        var queryRequest = CreateQueryRequest(ItemQuantitySelection.Ten, "name-desc", 1);
+
+        // Act
+        var (response, colors) = await ExecuteQuery(queryRequest);
+
+        // Assert
+        response.Error
+            .Should().Be(Error.None);
+        response.IsSuccess
+            .Should().BeTrue();
+
+        colors
+            .Should().BeInDescendingOrder(c => c.Name,
+                StringComparer.Create(new CultureInfo("uk-UA"), ignoreCase: true));
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_WithDifferentPageSizes_Should_ReturnCorrectNumberOfColors()
+    {
+        // Arrange
+        var queryRequestFive = CreateQueryRequest(ItemQuantitySelection.Five, "name-asc", 1);
+
+        // Act
+        var (responseFive, colorsFive) = await ExecuteQuery(queryRequestFive);
+
+        // Assert
+        responseFive.IsSuccess
+            .Should().BeTrue();
+        colorsFive.Count
+            .Should().BeLessOrEqualTo((int)ItemQuantitySelection.Five);
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_WithMultiplePages_Should_ReturnDifferentColors()
+    {
+        // Arrange
+        var totalColors = await Context.Set<VehicleColor>().CountAsync();
+
+        // Skip test if not enough data for pagination
+        if (totalColors <= (int)ItemQuantitySelection.Five)
+        {
+            return;
+        }
+
+        var queryRequestPage1 = CreateQueryRequest(ItemQuantitySelection.Five, "name-asc", 1);
+        var queryRequestPage2 = CreateQueryRequest(ItemQuantitySelection.Five, "name-asc", 2);
+
+        // Act
+        var (responsePage1, colorsPage1) = await ExecuteQuery(queryRequestPage1);
+        var (responsePage2, colorsPage2) = await ExecuteQuery(queryRequestPage2);
+
+        // Assert
+        responsePage1.IsSuccess
+            .Should().BeTrue();
+        responsePage2.IsSuccess
+            .Should().BeTrue();
+
+        // Pages should have different colors (no overlap)
+        colorsPage1.Select(c => c.Id)
+            .Should().NotIntersectWith(colorsPage2.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_Should_ReturnColorsWithValidHexCodes()
+    {
+        // Arrange
+        var queryRequest = CreateQueryRequest(ItemQuantitySelection.Ten, "name-asc", 1);
+
+        // Act
+        var (response, colors) = await ExecuteQuery(queryRequest);
+
+        // Assert
+        response.IsSuccess
+            .Should().BeTrue();
+
+        colors
+            .Should().NotBeEmpty();
+
+        // All colors should have valid hex color codes
+        colors
+            .Should().OnlyContain(c => !string.IsNullOrWhiteSpace(c.HexValue));
+
+        colors
+            .Should().OnlyContain(c => c.HexValue.StartsWith('#'));
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_WithMaxPageSize_Should_ReturnCorrectNumberOfColors()
+    {
+        // Arrange
+        var queryRequest = CreateQueryRequest(ItemQuantitySelection.Hundred, "name-asc", 1);
+
+        // Act
+        var (response, colors) = await ExecuteQuery(queryRequest);
+
+        // Assert
+        response.Error
+            .Should().Be(Error.None);
+        response.IsSuccess
+            .Should().BeTrue();
+
+        colors.Count
+            .Should().BeLessOrEqualTo((int)ItemQuantitySelection.Hundred);
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_Should_ReturnColorsWithUniqueIds()
+    {
+        // Arrange
+        var queryRequest = CreateQueryRequest(ItemQuantitySelection.Twenty, "name-asc", 1);
+
+        // Act
+        var (response, colors) = await ExecuteQuery(queryRequest);
+
+        // Assert
+        response.IsSuccess
+            .Should().BeTrue();
+
+        // All color IDs should be unique
+        colors.Select(c => c.Id)
+            .Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_Should_MatchDatabaseColorCount()
+    {
+        // Arrange
+        var totalColorsInDb = await Context.Set<VehicleColor>().CountAsync();
+
+        var queryRequest = CreateQueryRequest(ItemQuantitySelection.Hundred, "name-asc", 1);
+
+        // Act
+        var (response, colors) = await ExecuteQuery(queryRequest);
+
+        // Assert
+        response.IsSuccess
+            .Should().BeTrue();
+
+        // If database has fewer colors than page size, counts should match
+        if (totalColorsInDb <= (int)ItemQuantitySelection.Hundred)
+        {
+            colors.Count
+                .Should().Be(totalColorsInDb);
+        }
+    }
+
+    private static CollectionVehicleColorsQueryRequest CreateQueryRequest(
+        ItemQuantitySelection itemQuantity,
+        string sortingType,
+        int pageIndex) =>
+        new(new VehicleColorFilteringRequestParameters
+        {
+            ItemQuantity = itemQuantity,
+            SortingType = sortingType,
+            PageIndex = pageIndex
+        });
+
+    private async Task<(Result<PaginationResult<VehicleColorDto>> response, List<VehicleColorDto> colors)> ExecuteQuery(
+        CollectionVehicleColorsQueryRequest queryRequest)
+    {
+        var response = await Sender.Send(queryRequest);
+        return (response, response.Value!.Items);
     }
 }


### PR DESCRIPTION
Implementation of AG-52

Improve test coverage for one of the vehicle reference-data areas.

Pick an area where the existing tests are relatively repetitive or incomplete, then add several meaningful tests that check important create/update/delete or retrieval behavior. The goal is to make the coverage more useful, not just increase the number of tests.

Keep the changes aligned with the existing repository structure and testing approach.

# Implementation Plan

## Conceptual Checklist
- Identify a suitable reference-data area with incomplete coverage
- Study existing comprehensive test patterns (VehicleBrands/VehicleModels)
- Determine what CRUD/query operations exist for the target area
- Add unit tests for handlers and validators following established patterns
- Add integration tests if command operations exist
- Ensure tests are meaningful (edge cases, error scenarios), not just quantity

## Overview
Add comprehensive test coverage to the VehicleColors area, which currently only has 2 repetitive CollectionQuery tests. Will add tests following patterns from VehicleBrands: single item retrieval, count queries, error scenarios.

## Assumptions and Rules from CLAUDE.md
- Follow existing xUnit + NSubstitute + FluentAssertions patterns
- Match existing file organization (one test class per handler/validator)
- Test both success and failure paths
- Use established naming conventions: `Handler_Should...`, `Should_HaveError_When...`

## Step-by-Step Implementation
1. Examine VehicleColors source code to identify all available queries/commands
- Dependencies: None
- Tools/Files: src/LanosCertifiedStore.Application/VehicleColors/
2. Create unit tests for any Single/Count query handlers if they exist
- Dependencies: Step 1 findings
- Tools/Files: tests/ApplicationUnitTests/VehicleColors/
3. Add error scenario tests (null returns, empty collections)
- Dependencies: Steps 1-2
- Tools/Files: Same test files
4. Run tests to verify all pass
- Dependencies: Steps 1-3
- Tools: dotnet test

## Error Handling and Uncertainties
- VehicleColors may only have CollectionQuery (no Single/Count/Commands) - will verify source first
- If no Create/Update commands exist, scope limited to query tests and error scenarios