### PR TITLE
AG-53 Vehicle model command coverage(with skill)

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,225 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelWithNonExistingBrandId()
+    {
+        // Arrange
+        var (_, type, engineType, transmissionType, drivetrainType, bodyType) = await GetAllVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingBrandModel",
+            Guid.NewGuid(),
+            type.Id,
+            2010,
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelWithNonExistingVehicleTypeId()
+    {
+        // Arrange
+        var (brand, _, engineType, transmissionType, drivetrainType, bodyType) = await GetAllVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingTypeModel",
+            brand.Id,
+            Guid.NewGuid(),
+            2010,
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelWithNonExistingEngineTypeId()
+    {
+        // Arrange
+        var (brand, type, _, transmissionType, drivetrainType, bodyType) = await GetAllVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingEngineTypeModel",
+            brand.Id,
+            type.Id,
+            2010,
+            2020,
+            [Guid.NewGuid()],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelWithNonExistingTransmissionTypeId()
+    {
+        // Arrange
+        var (brand, type, engineType, _, drivetrainType, bodyType) = await GetAllVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingTransmissionTypeModel",
+            brand.Id,
+            type.Id,
+            2010,
+            2020,
+            [engineType.Id],
+            [Guid.NewGuid()],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelWithNonExistingDrivetrainTypeId()
+    {
+        // Arrange
+        var (brand, type, engineType, transmissionType, _, bodyType) = await GetAllVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingDrivetrainTypeModel",
+            brand.Id,
+            type.Id,
+            2010,
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [Guid.NewGuid()],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelWithNonExistingBodyTypeId()
+    {
+        // Arrange
+        var (brand, type, engineType, transmissionType, drivetrainType, _) = await GetAllVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingBodyTypeModel",
+            brand.Id,
+            type.Id,
+            2010,
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [Guid.NewGuid()]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelWithInvalidProductionYearRange()
+    {
+        // Arrange
+        var (brand, type, engineType, transmissionType, drivetrainType, bodyType) = await GetAllVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "InvalidYearRangeModel",
+            brand.Id,
+            type.Id,
+            2020,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelWithNonExistingId()
+    {
+        // Arrange
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypesForUpdate();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            Guid.NewGuid(),
+            2025,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelWithNonExistingEngineTypeId()
+    {
+        // Arrange
+        var model = await GetUpdatedModel();
+        var (_, transmissionType, drivetrainType, bodyType) = await GetVehicleTypesForUpdate();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            model.Id,
+            model.MaximumProductionYear,
+            [Guid.NewGuid()],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelWithInvalidProductionYearRange()
+    {
+        // Arrange
+        var model = await GetUpdatedModel();
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypesForUpdate();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            model.Id,
+            model.MinimalProductionYear - 10,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act & Assert
+        await AssertCommandFailure(commandRequest);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(
@@ -204,5 +417,40 @@ public sealed class VehicleModelCommandsIntegrationTests(
             availableDrivetrainTypes.Select(x => x.Id),
             availableBodyTypes.Select(x => x.Id)
         );
+    }
+
+    private async Task<(VehicleBrand brand, VehicleType type, VehicleEngineType engineType,
+        VehicleTransmissionType transmissionType, VehicleDrivetrainType drivetrainType,
+        VehicleBodyType bodyType)> GetAllVehicleTypes()
+    {
+        return (
+            await Context.Set<VehicleBrand>().FirstAsync(),
+            await Context.Set<VehicleType>().FirstAsync(),
+            await Context.Set<VehicleEngineType>().FirstAsync(),
+            await Context.Set<VehicleTransmissionType>().FirstAsync(),
+            await Context.Set<VehicleDrivetrainType>().FirstAsync(),
+            await Context.Set<VehicleBodyType>().FirstAsync()
+        );
+    }
+
+    private async Task<(VehicleEngineType engineType, VehicleTransmissionType transmissionType,
+        VehicleDrivetrainType drivetrainType, VehicleBodyType bodyType)> GetVehicleTypesForUpdate()
+    {
+        return (
+            await Context.Set<VehicleEngineType>().FirstAsync(),
+            await Context.Set<VehicleTransmissionType>().FirstAsync(),
+            await Context.Set<VehicleDrivetrainType>().FirstAsync(),
+            await Context.Set<VehicleBodyType>().FirstAsync()
+        );
+    }
+
+    private async Task AssertCommandFailure<T>(T commandRequest) where T : notnull
+    {
+        var response = await Sender.Send(commandRequest);
+
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
     }
 }


### PR DESCRIPTION
Implementation of AG-53

Improve the integration test coverage for vehicle model write operations.

The current coverage is not sufficient for the kinds of edge cases that can happen when creating or updating vehicle models with related vehicle metadata. Add a small but meaningful set of tests that would help prevent regressions in this area.

Keep the implementation consistent with the existing test style in the repository. Avoid overengineering and avoid changing production code unless the tests reveal a real issue.

# Implementation Plan

## Conceptual Checklist

- Identify untested edge cases in existing VehicleModelCommandsIntegrationTests.cs
- Follow existing test patterns (xUnit, FluentAssertions, Arrange/Act/Assert)
- Focus on vehicle model write operations with related metadata
- Keep tests small and meaningful (avoid overengineering)
- Verify tests run against Testcontainers infrastructure

## Overview

Add integration tests to VehicleModelCommandsIntegrationTests.cs covering edge cases for vehicle model create/update operations with related metadata (engine types, body types, etc.), including validation failures for non-existing IDs, duplicate names, and production year constraints.

## Assumptions and Rules from CLAUDE.md

- No CLAUDE.md found; follow existing test patterns in the repository
- Use same test infrastructure (IntegrationTestsWebApplicationFactory)
- Match naming conventions: `Send_[Operation]_Should_[Behavior]`
- Use FluentAssertions with chained assertions

## Step-by-Step Implementation

1. Add test for create with non-existing brand ID
- Dependencies: None
- Files: VehicleModelCommandsIntegrationTests.cs

2. Add test for create with non-existing vehicle type ID
- Dependencies: None
- Files: VehicleModelCommandsIntegrationTests.cs

3. Add test for create with non-existing metadata type IDs (engine/body/drivetrain/transmission)
- Dependencies: None
- Files: VehicleModelCommandsIntegrationTests.cs

4. Add test for create with duplicate model name
- Dependencies: None
- Files: VehicleModelCommandsIntegrationTests.cs

5. Add test for update non-existing model ID
- Dependencies: None
- Files: VehicleModelCommandsIntegrationTests.cs

6. Add test for production year edge cases (min > max)
- Dependencies: None
- Files: VehicleModelCommandsIntegrationTests.cs

## Error Handling and Uncertainties

- May need to verify exact error messages returned match VehicleModelValidatorMessages
- Database seeding assumed to provide enough test data for related entities
- If tests reveal production code issues, document but avoid changes unless truly broken