### PR TITLE
AG-55 Reference data command consistency(with skill)

### DIFF
--- a/tests/ApplicationUnitTests/VehicleBrands/UpdateVehicleBrandCommand/UpdateVehicleBrandCommandRequestValidatorTests.cs
+++ b/tests/ApplicationUnitTests/VehicleBrands/UpdateVehicleBrandCommand/UpdateVehicleBrandCommandRequestValidatorTests.cs
@@ -1,0 +1,64 @@
+using System.Linq.Expressions;
+using FluentValidation.TestHelper;
+using LanosCertifiedStore.Application.Shared.ValidationRelated;
+using LanosCertifiedStore.Application.VehicleBrands;
+using LanosCertifiedStore.Application.VehicleBrands.Commands.UpdateVehicleBrandRelated;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+
+namespace ApplicationUnitTests.VehicleBrands.UpdateVehicleBrandCommand;
+
+public sealed class UpdateVehicleBrandCommandRequestValidatorTests
+{
+    private const int MaxNameLength = 64;
+
+    private readonly IValidationHelper _validationHelper = Substitute.For<IValidationHelper>();
+    private readonly UpdateVehicleBrandCommandRequestValidator _validator;
+
+    public UpdateVehicleBrandCommandRequestValidatorTests()
+    {
+        _validator = new UpdateVehicleBrandCommandRequestValidator(_validationHelper);
+    }
+
+    [Fact]
+    public async Task Should_HaveError_WhenUpdatedNameIsEmpty()
+    {
+        await AssertValidationError(string.Empty);
+    }
+
+    [Fact]
+    public async Task Should_HaveError_WhenUpdatedNameIsTooShort()
+    {
+        await AssertValidationError("A");
+    }
+
+    [Fact]
+    public async Task Should_HaveError_WhenUpdatedNameIsTooLong()
+    {
+        await AssertValidationError(new string('A', MaxNameLength + 1));
+    }
+
+    [Fact]
+    public async Task Should_HaveError_WhenUpdatedNameIsNotUnique()
+    {
+        _validationHelper
+            .CheckAspectValueUniqueness(Arg.Any<string>(), Arg.Any<Expression<Func<VehicleBrand, bool>>>())
+            .Returns(false);
+
+        var result = await ValidateRequest("ExistingBrand");
+
+        result.ShouldHaveValidationErrorFor(x => x.UpdatedName)
+            .WithErrorMessage(VehicleBrandValidatorMessages.AlreadyExistingNameValue);
+    }
+
+    private async Task AssertValidationError(string updatedName)
+    {
+        var result = await ValidateRequest(updatedName);
+        result.ShouldHaveValidationErrorFor(x => x.UpdatedName);
+    }
+
+    private async Task<TestValidationResult<UpdateVehicleBrandCommandRequest>> ValidateRequest(string updatedName)
+    {
+        var request = new UpdateVehicleBrandCommandRequest(Guid.NewGuid(), updatedName);
+        return await _validator.TestValidateAsync(request);
+    }
+}


### PR DESCRIPTION
Implementation of AG-55

Improve test coverage for one of the vehicle reference-data areas.

Pick an area where the existing tests are relatively repetitive or incomplete, then add several meaningful tests that check important create/update/delete or retrieval behavior. The goal is to make the coverage more useful, not just increase the number of tests.

Keep the changes aligned with the existing repository structure and testing approach.

# Implementation Plan

## Conceptual Checklist

- Identify the vehicle reference-data area with most incomplete/repetitive test coverage
- Analyze the existing test patterns from well-covered areas (VehicleBrands, VehicleModels)
- Determine which types of tests are missing (handler tests, validator tests, integration tests)
- Follow established naming conventions and file organization
- Add meaningful tests that verify important CRUD behaviors
- Ensure tests use existing testing infrastructure (IntegrationTestBase, NSubstitute, FluentAssertions)

## Overview

Add comprehensive test coverage to VehicleBrands by creating the missing UpdateVehicleBrandCommandRequestValidatorTests, mirroring the pattern from CreateVehicleBrandCommandRequestValidatorTests. This completes the VehicleBrands testing to the same standard as VehicleModels.

## Assumptions and Rules from CLAUDE.md

- No CLAUDE.md found in project; following established patterns from existing tests
- Tests use xUnit, FluentAssertions, NSubstitute, FluentValidation.TestHelper
- Integration tests inherit from IntegrationTestBase
- Unit tests mock services using NSubstitute
- Validator tests use TestValidateAsync pattern

## Step-by-Step Implementation

1. Create UpdateVehicleBrandCommandRequestValidatorTests.cs
- Location: tests/ApplicationUnitTests/VehicleBrands/
- Test cases: empty name, too short name, too long name, non-unique name
- Mirror CreateVehicleBrandCommandRequestValidatorTests structure

2. Consider adding integration tests for edge cases in VehicleBrandCommandsIntegrationTests
- Test Create with duplicate name should fail
- Test Update with invalid name length should fail

## Error Handling and Uncertainties

- Validator implementation may have different validation rules than Create; verify by reading UpdateVehicleBrandCommandValidator.cs
- If VehicleBrands doesn't have Create/Update commands for certain sub-types, tests would need to use existing seeded data