### PR TITLE
SCRUM-277 test skill

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,177 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfNameAlreadyExists()
+    {
+        // Arrange
+        // Use the existing "test" model name which is already in the database
+        var commandRequest = await InstantiateValidCreateRequest();
+
+        // Act
+        var firstResponse = await Sender.Send(commandRequest);
+        var secondResponse = await Sender.Send(commandRequest);
+
+        // Assert
+        firstResponse.IsSuccess
+            .Should().BeTrue();
+        AssertFailureResponse(secondResponse);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfBrandDoesNotExist()
+    {
+        // Arrange
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypes();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "unique-model-name",
+            Guid.NewGuid(), // Non-existent brand ID
+            type.Id,
+            2020,
+            2023,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfTypeDoesNotExist()
+    {
+        // Arrange
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypes();
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "unique-model-name-2",
+            brand.Id,
+            Guid.NewGuid(), // Non-existent type ID
+            2020,
+            2023,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfRelatedTypeDoesNotExist()
+    {
+        // Arrange
+        var (_, transmissionType, drivetrainType, bodyType) = await GetVehicleTypes();
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "unique-model-name-3",
+            brand.Id,
+            type.Id,
+            2020,
+            2023,
+            [Guid.NewGuid()], // Non-existent engine type ID
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfProductionYearRangeIsInvalid()
+    {
+        // Arrange
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypes();
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "unique-model-name-4",
+            brand.Id,
+            type.Id,
+            2023, // Minimal year greater than maximum year
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfModelDoesNotExist()
+    {
+        // Arrange
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetVehicleTypes();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            Guid.NewGuid(), // Non-existent model ID
+            2025,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfRelatedTypeDoesNotExist()
+    {
+        // Arrange
+        var existingModel = await GetUpdatedModel();
+        var (_, transmissionType, drivetrainType, bodyType) = await GetVehicleTypes();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            existingModel.MinimalProductionYear + 1,
+            [Guid.NewGuid()], // Non-existent engine type ID
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(
@@ -204,5 +369,20 @@ public sealed class VehicleModelCommandsIntegrationTests(
             availableDrivetrainTypes.Select(x => x.Id),
             availableBodyTypes.Select(x => x.Id)
         );
+    }
+
+    private async Task<(VehicleEngineType, VehicleTransmissionType, VehicleDrivetrainType, VehicleBodyType)> GetVehicleTypes()
+    {
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        return (engineType, transmissionType, drivetrainType, bodyType);
+    }
+
+    private static void AssertFailureResponse<T>(Result<T> response)
+    {
+        response.Error.Should().NotBeNull();
+        response.IsSuccess.Should().BeFalse();
     }
 }


### PR DESCRIPTION
Implementation of SCRUM-277

Improve the integration test coverage for vehicle model write operations.

The current coverage is not sufficient for the kinds of edge cases that can happen when creating or updating vehicle models with related vehicle metadata. Add a small but meaningful set of tests that would help prevent regressions in this area.

Keep the implementation consistent with the existing test style in the repository. Avoid overengineering and avoid changing production code unless the tests reveal a real issue//

# Implementation Plan

## Conceptual Checklist

- Review existing test patterns and naming conventions in VehicleModelCommandsIntegrationTests.cs
- Identify edge cases from validators: name uniqueness, production year validation, related entity existence
- Prioritize tests that cover critical regressions (non-existent entities, validation failures)
- Keep tests focused and avoid overengineering
- Maintain AAA (Arrange-Act-Assert) pattern used in existing tests

## Overview

Add 5-7 integration tests to VehicleModelCommandsIntegrationTests.cs covering edge cases for vehicle model write operations with related metadata: duplicate names, invalid production years, non-existent related entity IDs (brand, type, engine/transmission/drivetrain/body types), and updating non-existent models.

## Assumptions and Rules from CLAUDE.md

- No project CLAUDE.md found; following codebase conventions observed in existing tests
- Use existing IntegrationTestBase class and factory pattern
- Follow naming convention: `Send_[Action]Request_[Should/ShouldNot]_[Result]`
- Use FluentAssertions for assertions
- Keep tests independent and self-contained

## Step-by-Step Implementation

1. Add test for create with duplicate name
- Dependencies: Existing seeded data with known model name
- Files: VehicleModelCommandsIntegrationTests.cs

2. Add test for create with non-existent brand ID
- Dependencies: None (uses Guid.NewGuid())
- Files: VehicleModelCommandsIntegrationTests.cs

3. Add test for create with non-existent related type IDs
- Dependencies: Valid brand/type from seed data
- Files: VehicleModelCommandsIntegrationTests.cs

4. Add test for create with invalid production years (min > max)
- Dependencies: Valid brand/type from seed data
- Files: VehicleModelCommandsIntegrationTests.cs

5. Add test for update with non-existent model ID
- Dependencies: None
- Files: VehicleModelCommandsIntegrationTests.cs

6. Add test for update with non-existent related type IDs
- Dependencies: Existing model from seed data
- Files: VehicleModelCommandsIntegrationTests.cs

## Error Handling and Uncertainties

- Seed data availability: Tests rely on seeded data; verified 'test' model exists in current tests
- Test isolation: Each test should not interfere with others; use unique names or verify cleanup
- Max production year is nullable; ensure tests cover null vs invalid scenarios appropriately