### PR TITLE
SCRUM-279 иапиап

### DIFF
--- a/tests/IntegrationTests/VehicleColors/VehicleColorQueriesIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleColors/VehicleColorQueriesIntegrationTests.cs
@@ -10,6 +10,26 @@ namespace IntegrationTests.VehicleColors;
 public sealed class VehicleColorQueriesIntegrationTests(
     IntegrationTestsWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
+    private static readonly StringComparer UkrainianCaseInsensitiveComparer =
+        StringComparer.Create(new CultureInfo("uk-UA"), ignoreCase: true);
+
+    private static CollectionVehicleColorsQueryRequest CreateQueryRequest(
+        ItemQuantitySelection itemQuantity,
+        string sortingType,
+        int pageIndex) =>
+        new(new VehicleColorFilteringRequestParameters
+        {
+            ItemQuantity = itemQuantity,
+            SortingType = sortingType,
+            PageIndex = pageIndex
+        });
+
+    private static void AssertSuccessfulResponse<T>(Result<T> response)
+    {
+        response.Error.Should().Be(Error.None);
+        response.IsSuccess.Should().BeTrue();
+    }
+
     [Fact]
     public async Task Send_CollectionRequest_Should_ReturnCollectionOfColors()
     {
@@ -32,9 +52,76 @@ public sealed class VehicleColorQueriesIntegrationTests(
         response.IsSuccess.Should().BeTrue();
 
         colors
-            .Should().BeInAscendingOrder(b => b.Name, 
+            .Should().BeInAscendingOrder(b => b.Name,
                 StringComparer.Create(new CultureInfo("uk-UA"), ignoreCase: true));
         colors.Count
             .Should().BeLessOrEqualTo((int)ItemQuantitySelection.Ten);
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_WithDescendingSort_Should_ReturnColorsInDescendingOrder()
+    {
+        // Arrange
+        var queryRequest = CreateQueryRequest(ItemQuantitySelection.Ten, "name-desc", pageIndex: 1);
+
+        // Act
+        var response = await Sender.Send(queryRequest);
+        var colors = response.Value!.Items;
+
+        // Assert
+        AssertSuccessfulResponse(response);
+
+        colors
+            .Should().BeInDescendingOrder(c => c.Name, UkrainianCaseInsensitiveComparer);
+        colors.Count
+            .Should().BeLessOrEqualTo((int)ItemQuantitySelection.Ten);
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_WithPageTwo_Should_ReturnDifferentColorsFromPageOne()
+    {
+        // Arrange
+        var queryRequestPage1 = CreateQueryRequest(ItemQuantitySelection.Ten, "name-asc", pageIndex: 1);
+        var queryRequestPage2 = CreateQueryRequest(ItemQuantitySelection.Ten, "name-asc", pageIndex: 2);
+
+        // Act
+        var responsePage1 = await Sender.Send(queryRequestPage1);
+        var responsePage2 = await Sender.Send(queryRequestPage2);
+        var colorsPage1 = responsePage1.Value!.Items;
+        var colorsPage2 = responsePage2.Value!.Items;
+
+        // Assert
+        AssertSuccessfulResponse(responsePage1);
+        AssertSuccessfulResponse(responsePage2);
+
+        // If we have data on page 2, it should be different from page 1
+        if (colorsPage2.Count > 0)
+        {
+            var page1Ids = colorsPage1.Select(c => c.Id).ToList();
+            var page2Ids = colorsPage2.Select(c => c.Id).ToList();
+
+            page2Ids
+                .Should().NotIntersectWith(page1Ids,
+                    "page 2 should contain different items than page 1");
+        }
+    }
+
+    [Fact]
+    public async Task Send_CollectionRequest_WithTwentyItems_Should_ReturnUpToTwentyColors()
+    {
+        // Arrange
+        var queryRequest = CreateQueryRequest(ItemQuantitySelection.Twenty, "name-asc", pageIndex: 1);
+
+        // Act
+        var response = await Sender.Send(queryRequest);
+        var colors = response.Value!.Items;
+
+        // Assert
+        AssertSuccessfulResponse(response);
+
+        colors
+            .Should().BeInAscendingOrder(c => c.Name, UkrainianCaseInsensitiveComparer);
+        colors.Count
+            .Should().BeLessOrEqualTo((int)ItemQuantitySelection.Twenty);
     }
 }


### PR DESCRIPTION
Implementation of SCRUM-279

Improve test coverage for one of the vehicle reference-data areas.

Pick an area where the existing tests are relatively repetitive or incomplete, then add several meaningful tests that check important create/update/delete or retrieval behavior. The goal is to make the coverage more useful, not just increase the number of tests.

Keep the changes aligned with the existing repository structure and testing approach.

# Implementation Plan

## Conceptual Checklist

- Identify the vehicle reference-data area with most incomplete tests
- Study the comprehensive VehicleBrands tests as the reference pattern
- Verify what queries/commands exist for the chosen area
- Add meaningful tests that align with existing patterns
- Ensure tests cover retrieval, sorting, pagination, and error cases

## Overview

Improve test coverage for VehicleColors (or another reference-data area) by adding integration tests for descending sort order, pagination edge cases, empty result handling, and filtering behavior. The existing test only covers ascending sort with 10 items on page 1.

## Assumptions and Rules from CLAUDE.md

- No CLAUDE.md file exists in the repository
- Follow existing test naming conventions: `Send_[RequestType]_Should_[ExpectedBehavior]`
- Use xUnit with FluentAssertions and NSubstitute
- Maintain AAA pattern (Arrange, Act, Assert)
- Use IntegrationTestBase for integration tests
- Keep tests focused and meaningful per task requirement

## Step-by-Step Implementation

1. Select VehicleColors as target area (has unique hex code property)
- Dependencies: None
- Files: tests/IntegrationTests/VehicleColors/VehicleColorQueriesIntegrationTests.cs

2. Add test for descending sort order
- Dependencies: Step 1
- Verify collection returns items in descending order when SortingType="name-desc"

3. Add test for pagination (page 2 differs from page 1)
- Dependencies: Step 1
- Verify different items returned on different pages

4. Add test for ItemQuantitySelection variations
- Dependencies: Step 1
- Test different quantity selections (Five, Twenty)

5. Run tests to verify they pass
- Dependencies: Steps 2-4
- Command: dotnet test

## Error Handling and Uncertainties

- If VehicleColors has limited seed data, pagination tests may fail - adjust page size or use available data
- Descending sort test assumes seed data exists with different names
- No CRUD commands exist for VehicleColors so only query tests possible