### PR TITLE
AG-57 test validation

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,145 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_PersistModelWhenBrandIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingBrandId = Guid.NewGuid();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetCommonVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingBrandModel",
+            nonExistingBrandId,
+            type.Id,
+            2020,
+            2024,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var modelInDatabase = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name.Equals("NonExistingBrandModel"));
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.Error.Message
+            .Should().Contain("Brand with such ID does not exist");
+        response.IsSuccess
+            .Should().BeFalse();
+        modelInDatabase
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_PersistModelWhenTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var nonExistingTypeId = Guid.NewGuid();
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetCommonVehicleTypes();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingTypeModel",
+            brand.Id,
+            nonExistingTypeId,
+            2020,
+            2024,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var modelInDatabase = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name.Equals("NonExistingTypeModel"));
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.Error.Message
+            .Should().Contain("Type with such ID does not exist");
+        response.IsSuccess
+            .Should().BeFalse();
+        modelInDatabase
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_PersistModelWhenNameAlreadyExists()
+    {
+        // Arrange
+        var commandRequest = await InstantiateValidCreateRequest();
+        var initialModelCount = await Context.Set<VehicleModel>()
+            .CountAsync(m => m.Name.Equals(ModelName));
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var finalModelCount = await Context.Set<VehicleModel>()
+            .CountAsync(m => m.Name.Equals(ModelName));
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.Error.Message
+            .Should().Contain("already exists");
+        response.IsSuccess
+            .Should().BeFalse();
+        finalModelCount
+            .Should().Be(initialModelCount);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelWhenEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var updatedModel = await GetUpdatedModel();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var originalEngineTypeIds = updatedModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            updatedModel.Id,
+            updatedModel.MaximumProductionYear,
+            originalEngineTypeIds.Append(nonExistingEngineTypeId),
+            updatedModel.AvailableTransmissionTypes.Select(t => t.Id),
+            updatedModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            updatedModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Detach the entity to ensure fresh data from database
+        Context.Entry(updatedModel).State = EntityState.Detached;
+        var modelAfterFailedUpdate = await GetUpdatedModel();
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.Error.Message
+            .Should().Contain("Engine type with ID");
+        response.IsSuccess
+            .Should().BeFalse();
+        modelAfterFailedUpdate.AvailableEngineTypes
+            .Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(
@@ -204,5 +337,15 @@ public sealed class VehicleModelCommandsIntegrationTests(
             availableDrivetrainTypes.Select(x => x.Id),
             availableBodyTypes.Select(x => x.Id)
         );
+    }
+
+    private async Task<(VehicleEngineType EngineType, VehicleTransmissionType TransmissionType, VehicleDrivetrainType DrivetrainType, VehicleBodyType BodyType)> GetCommonVehicleTypes()
+    {
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+
+        return (engineType, transmissionType, drivetrainType, bodyType);
     }
 }

--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -12,6 +12,12 @@ public sealed class VehicleModelCommandsIntegrationTests(
     IntegrationTestsWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     private const string ModelName = "test";
+
+    // Error message fragments for assertions
+    private const string BrandNotFoundErrorFragment = "Brand with such ID does not exist";
+    private const string TypeNotFoundErrorFragment = "Type with such ID does not exist";
+    private const string ModelAlreadyExistsErrorFragment = "already exists";
+    private const string EngineTypeNotFoundErrorFragment = "Engine type with ID";
     
     [Fact]
     public async Task Send_CreateRequest_Should_AddNewModelIfRequestIsValid()
@@ -116,7 +122,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
         // Arrange
         var nonExistingBrandId = Guid.NewGuid();
         var type = await Context.Set<VehicleType>().FirstAsync();
-        var (engineType, transmissionType, drivetrainType, bodyType) = await GetCommonVehicleTypes();
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetFirstAvailableVehicleTypes();
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             "NonExistingBrandModel",
@@ -136,12 +142,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
             .FirstOrDefaultAsync(m => m.Name.Equals("NonExistingBrandModel"));
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.Error.Message
-            .Should().Contain("Brand with such ID does not exist");
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertCommandFailed(response, BrandNotFoundErrorFragment);
         modelInDatabase
             .Should().BeNull();
     }
@@ -152,7 +153,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
         // Arrange
         var brand = await Context.Set<VehicleBrand>().FirstAsync();
         var nonExistingTypeId = Guid.NewGuid();
-        var (engineType, transmissionType, drivetrainType, bodyType) = await GetCommonVehicleTypes();
+        var (engineType, transmissionType, drivetrainType, bodyType) = await GetFirstAvailableVehicleTypes();
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             "NonExistingTypeModel",
@@ -172,12 +173,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
             .FirstOrDefaultAsync(m => m.Name.Equals("NonExistingTypeModel"));
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.Error.Message
-            .Should().Contain("Type with such ID does not exist");
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertCommandFailed(response, TypeNotFoundErrorFragment);
         modelInDatabase
             .Should().BeNull();
     }
@@ -196,12 +192,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
             .CountAsync(m => m.Name.Equals(ModelName));
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.Error.Message
-            .Should().Contain("already exists");
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertCommandFailed(response, ModelAlreadyExistsErrorFragment);
         finalModelCount
             .Should().Be(initialModelCount);
     }
@@ -232,12 +223,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
         var modelAfterFailedUpdate = await GetUpdatedModel();
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.Error.Message
-            .Should().Contain("Engine type with ID");
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertCommandFailed(response, EngineTypeNotFoundErrorFragment);
         modelAfterFailedUpdate.AvailableEngineTypes
             .Select(t => t.Id)
             .Should().BeEquivalentTo(originalEngineTypeIds);
@@ -339,7 +325,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
         );
     }
 
-    private async Task<(VehicleEngineType EngineType, VehicleTransmissionType TransmissionType, VehicleDrivetrainType DrivetrainType, VehicleBodyType BodyType)> GetCommonVehicleTypes()
+    private async Task<(VehicleEngineType EngineType, VehicleTransmissionType TransmissionType, VehicleDrivetrainType DrivetrainType, VehicleBodyType BodyType)> GetFirstAvailableVehicleTypes()
     {
         var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
         var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
@@ -347,5 +333,15 @@ public sealed class VehicleModelCommandsIntegrationTests(
         var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
 
         return (engineType, transmissionType, drivetrainType, bodyType);
+    }
+
+    private static void AssertCommandFailed(Result response, string expectedErrorFragment)
+    {
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+        response.Error.Message
+            .Should().Contain(expectedErrorFragment);
     }
 }


### PR DESCRIPTION
Implementation of AG-57

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Review existing test patterns and naming conventions in VehicleModelCommandsIntegrationTests.cs
- Identify seeded reference data available (brands, types, models)
- Understand validator rules for Create and Update commands
- Plan 3-4 edge case tests based on suggested cases
- Ensure tests are independent and deterministic

## Overview

Add at least 3 new integration tests to VehicleModelCommandsIntegrationTests.cs covering edge cases for Create and Update commands. Tests will verify: (1) Create fails with non-existing BrandId/TypeId, (2) Create fails with duplicate model name, (3) Update fails with non-existing type IDs without partial persistence.

## Assumptions and Rules from CLAUDE.md

- No CLAUDE.md found; follow existing codebase conventions
- Use existing IntegrationTestBase infrastructure (Sender, Context)
- Follow Arrange/Act/Assert pattern from existing tests
- Use FluentAssertions for assertions
- Verify both Result.IsSuccess/Error and database state
- Use seeded data (Toyota, Ford brands; existing VehicleTypes)
- Test method naming: Send_*Request_Should_* pattern

## Step-by-Step Implementation

1. Add test: Create with non-existing BrandId should fail and not persist
- Use Guid.NewGuid() for fake BrandId, valid TypeId and type IDs
- Assert: response.IsSuccess is false, error contains brand message
- Assert: no new VehicleModel with that name exists in Context

2. Add test: Create with duplicate model name should fail
- Use existing "test" model name (already seeded)
- Assert: response.IsSuccess is false, error contains 'already exists'
- Assert: count of models with name "test" unchanged

3. Add test: Update with non-existing EngineTypeId should fail
- Get existing model, use Guid.NewGuid() for one EngineTypeId
- Assert: response.IsSuccess is false
- Assert: model's AvailableEngineTypes unchanged in database

4. (Optional) Add test: Create with non-existing TypeId fails

## Error Handling and Uncertainties

- Use deterministic model lookup (FirstAsync with specific name/brand filter)
- Detach entities before re-querying to ensure fresh database state
- Non-existing GUIDs: use Guid.NewGuid() to guarantee non-existence