### PR TITLE
AG-58 test semi-auto validation

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,214 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfBrandIdDoesNotExist()
+    {
+        // Arrange
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var nonExistingBrandId = Guid.NewGuid();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            $"Model_{Guid.NewGuid()}",
+            nonExistingBrandId,
+            type.Id,
+            2005,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        var countBefore = await Context.Set<VehicleModel>().CountAsync();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify no model was persisted
+        var countAfter = await Context.Set<VehicleModel>().CountAsync();
+        countAfter
+            .Should().Be(countBefore);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfVehicleTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var nonExistingTypeId = Guid.NewGuid();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            $"Model_{Guid.NewGuid()}",
+            brand.Id,
+            nonExistingTypeId,
+            2005,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        var countBefore = await Context.Set<VehicleModel>().CountAsync();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify no model was persisted
+        var countAfter = await Context.Set<VehicleModel>().CountAsync();
+        countAfter
+            .Should().Be(countBefore);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfEngineTypeIdsDoNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            $"Model_{Guid.NewGuid()}",
+            brand.Id,
+            type.Id,
+            2005,
+            2010,
+            [nonExistingEngineTypeId],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        var countBefore = await Context.Set<VehicleModel>().CountAsync();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify no model was persisted
+        var countAfter = await Context.Set<VehicleModel>().CountAsync();
+        countAfter
+            .Should().Be(countBefore);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfEngineTypeIdsDoNotExist()
+    {
+        // Arrange
+        var updatedModel = await GetUpdatedModel();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            updatedModel.Id,
+            updatedModel.MaximumProductionYear,
+            updatedModel.AvailableEngineTypes.Select(t => t.Id).Append(nonExistingEngineTypeId),
+            updatedModel.AvailableTransmissionTypes.Select(t => t.Id),
+            updatedModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            updatedModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        var originalEngineTypeIds = updatedModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify original relationships are unchanged
+        var modelAfter = await GetUpdatedModel();
+        var engineTypeIdsAfter = modelAfter.AvailableEngineTypes.Select(t => t.Id).ToList();
+        engineTypeIdsAfter
+            .Should().BeEquivalentTo(originalEngineTypeIds);
+        modelAfter.AvailableEngineTypes
+            .Should().NotContain(t => t.Id == nonExistingEngineTypeId);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfNameAlreadyExistsForBrand()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>()
+            .FirstAsync(m => m.Name == ModelName);
+
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            ModelName, // Duplicate name
+            existingModel.VehicleBrandId,
+            type.Id,
+            2005,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        Task<int> GetModelCountForBrandAndName() => Context.Set<VehicleModel>()
+            .Where(m => m.Name == ModelName && m.VehicleBrandId == existingModel.VehicleBrandId)
+            .CountAsync();
+
+        var countBefore = await GetModelCountForBrandAndName();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify no duplicate model was persisted
+        var countAfter = await GetModelCountForBrandAndName();
+        countAfter
+            .Should().Be(countBefore);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(


### PR DESCRIPTION
Implementation of AG-58

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

1. Review existing test patterns in VehicleModelCommandsIntegrationTests.cs
2. Identify edge cases from validators and command handlers
3. Design tests that verify Result state AND database state
4. Use seeded reference data for valid IDs and generate non-existing GUIDs for failure cases
5. Ensure tests are deterministic and order-independent
6. Follow existing naming conventions

## Overview

Add 4 new integration tests to VehicleModelCommandsIntegrationTests.cs covering:
1. Create with non-existing BrandId fails and doesn't persist
2. Create with non-existing TypeId fails and doesn't persist
3. Update with non-existing type IDs fails without persisting changes
4. Duplicate model name creation fails

## Assumptions and Rules

- **Assumption**: Seeded test data contains at least one VehicleBrand, VehicleType, and all type entities (discovered via FirstAsync in existing tests)
- **Rule**: No mocks/in-memory DB - use real PostgreSQL via testcontainers
- **Rule**: Verify both Result.IsSuccess/Error AND database state via Context
- **Rule**: Use existing helper methods pattern (InstantiateValidCreateRequest)
- **Rule**: Follow naming convention: `Send__Should_If`

## Step-by-Step Implementation

1. Add test: Create with non-existing BrandId
- Create request with Guid.NewGuid() for BrandId (guaranteed non-existing)
- Verify Result.IsSuccess is false, Error contains validation message
- Query database to confirm no VehicleModel was persisted

2. Add test: Create with non-existing engine/body/drivetrain/transmission type IDs
- Use valid brand/type, but include one Guid.NewGuid() in type collections
- Verify failure and no persistence

3. Add test: Update with non-existing type IDs
- Get existing model via GetUpdatedModel()
- Send update with valid model ID but invalid type IDs
- Verify KeyNotFoundException is caught and Result shows failure
- Verify original model relationships unchanged

4. Add test: Duplicate model name fails
- Create valid request with existing model name ("test")
- Verify validation fails, model not persisted

## Error Handling and Uncertainties

- If seeded data doesn't include model named "test", adjust to use any existing model name via Context query
- Validators run before handlers, so non-existing type IDs fail at validation, not command execution