### PR TITLE
AG-61 test validation manual

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,105 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_PersistModelWhenBrandIdDoesNotExist()
+    {
+        // Arrange
+        var validRequest = await InstantiateValidCreateRequest();
+        var commandRequest = validRequest with { BrandId = Guid.Empty };
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelCountByName(commandRequest.Name, expectedCount: 0);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_PersistModelWhenTypeIdDoesNotExist()
+    {
+        // Arrange
+        var validRequest = await InstantiateValidCreateRequest();
+        var commandRequest = validRequest with { TypeId = Guid.Empty };
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelCountByName(commandRequest.Name, expectedCount: 0);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_PersistModelWhenEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var validRequest = await InstantiateValidCreateRequest();
+        var invalidEngineTypeIds = validRequest.AvailableEngineTypesIds.Append(Guid.Empty);
+        var commandRequest = validRequest with { AvailableEngineTypesIds = invalidEngineTypeIds };
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelCountByName(commandRequest.Name, expectedCount: 0);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_PersistModelWhenNameAlreadyExists()
+    {
+        // Arrange
+        var validRequest = await InstantiateValidCreateRequest();
+        // Use ModelName constant which already exists in database (used by GetUpdatedModel)
+        var commandRequest = validRequest with { Name = ModelName };
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelCountByName(ModelName, expectedCount: 1);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_PartiallyUpdateWhenEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var existingModel = await GetUpdatedModel();
+        var originalEngineTypeIds = existingModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+        var originalMaxYear = existingModel.MaximumProductionYear;
+
+        var invalidEngineTypeIds = originalEngineTypeIds.Append(Guid.Empty);
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            2025,
+            invalidEngineTypeIds,
+            existingModel.AvailableTransmissionTypes.Select(t => t.Id),
+            existingModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            existingModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+
+        var unchangedModel = await GetUpdatedModel();
+        unchangedModel.MaximumProductionYear
+            .Should().Be(originalMaxYear);
+        unchangedModel.AvailableEngineTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(
@@ -204,5 +297,21 @@ public sealed class VehicleModelCommandsIntegrationTests(
             availableDrivetrainTypes.Select(x => x.Id),
             availableBodyTypes.Select(x => x.Id)
         );
+    }
+
+    private static void AssertFailureResponse(Result<Guid> response)
+    {
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+    }
+
+    private async Task AssertModelCountByName(string modelName, int expectedCount)
+    {
+        var modelCount = await Context.Set<VehicleModel>()
+            .CountAsync(m => m.Name.Equals(modelName));
+        modelCount
+            .Should().Be(expectedCount);
     }
 }


### PR DESCRIPTION
Implementation of AG-61

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Review existing VehicleModelCommandsIntegrationTests.cs structure and patterns
- Identify validation rules from CreateVehicleModelCommandRequestValidator and UpdateVehicleModelCommandRequestValidator
- Understand persistence behavior: validators run before handlers, preventing partial persistence on failure
- Map suggested edge cases to specific test methods following naming convention Method_Scenario_Should_ExpectedOutcome
- Verify CreateVehicleModelCommand and UpdateVehicleModelCommand behavior (create adds to context, update replaces collections)
- Plan database state assertions using Context.Set() queries with Include() for relationships
- Ensure tests use real seeded data from Context (VehicleBrand, VehicleType, VehicleEngineType, etc.)

## Overview

Add at least 3 meaningful integration tests to VehicleModelCommandsIntegrationTests.cs covering realistic edge cases for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Tests will validate command behavior when: (1) creating with non-existing related entity IDs (brand, type, engine/body/transmission/drivetrain types), (2) updating with non-existing type IDs without partial persistence, (3) verifying update operations completely replace type collections. All tests follow existing patterns: inherit from IntegrationTestBase, send via MediatR Sender, assert Result state, verify database side effects via Context queries.

## Assumptions and Rules from CLAUDE.md

**From lanos-test skill (project-specific)**:
- Naming: Method_Scenario_Should_ExpectedOutcome (e.g., Send_CreateRequest_ShouldNot_PersistModelWhenBrandIdDoesNotExist)
- Inherit IntegrationTestBase with primary constructor injection
- Send via Sender (MediatR), never directly invoke handlers
- Arrange using real Context data (await Context.Set().FirstAsync())
- Assert Result state (.IsSuccess, .Error) and database persistence (await Context.FindAsync, Include() for relationships)
- Invalid data: Guid.Empty for non-existing IDs, string.Empty for names
- Determinism: unique names using Guid.NewGuid() if needed
- Imports: IntegrationTests.Common, LanosCertifiedStore.Application.Shared.ResultRelated, Commands namespaces, Domain.Entities, Microsoft.EntityFrameworkCore

**Ambiguities and resolutions**:
- Test count: Task says "at least 3" but suggests 4+ scenarios → Resolution: Implement 4-5 high-value tests covering all suggested edge cases
- Duplicate name validation scope: Examined CreateVehicleModelCommandRequestValidator (lines 34-41) → Confirmed: global uniqueness check, not per-brand
- Update behavior: Examined UpdateVehicleModelCommand.UpdateAspectCollection → Confirmed: completely replaces collections via reflection (line 57)

## Step-by-Step Implementation

1. **Add test: Create with non-existing BrandId**
- Dependencies: Existing Context access pattern
- Tools: Read file, Edit to add test method
- Implementation: Use valid data except BrandId = Guid.Empty, verify response.IsSuccess = false, verify no VehicleModel persisted in database

2. **Add test: Create with non-existing TypeId**
- Dependencies: Step 1 complete
- Tools: Edit file
- Implementation: Use valid data except TypeId = Guid.Empty, verify validation failure, verify no persistence

3. **Add test: Create with non-existing EngineType in collection**
- Dependencies: Step 2 complete
- Tools: Edit file
- Implementation: Fetch valid brand/type/other types, include one Guid.Empty in AvailableEngineTypesIds, verify failure

4. **Add test: Update with non-existing EngineType fails without partial changes**
- Dependencies: Step 3 complete, GetUpdatedModel() helper available
- Tools: Edit file
- Implementation: Load existing model, attempt update with one invalid EngineType ID, verify error response, re-query model to confirm no changes persisted

5. **Add test: Update completely replaces type collections**
- Dependencies: Step 4 complete
- Tools: Edit file
- Implementation: Load model with Include() for all type collections, update with entirely new set of type IDs, verify old types removed and new types present

6. **Build and verify**
- Dependencies: All tests added
- Tools: Bash (dotnet build, dotnet test)
- Command: `dotnet build tests/IntegrationTests && dotnet test tests/IntegrationTests --filter "FullyQualifiedName~VehicleModelCommandsIntegrationTests"`

## Error Handling and Uncertainties

**Potential issues**:
- Test execution order dependency: Mitigated by using deterministic data (Guid.Empty for invalid IDs) and fetching fresh data per test
- Seeded data availability: Tests assume database contains at least one VehicleBrand, VehicleType, and multiple instances of each type entity. If seed data is insufficient, tests will fail at arrange phase (FirstAsync will throw). Resolution: Verify seed data or adjust queries to handle minimal data.
- Transaction isolation: IntegrationTestBase should handle transaction rollback between tests. If not, tests may interfere. Resolution: Trust existing infrastructure (other tests use same base).
- Update test complexity: Verifying complete replacement requires tracking old vs new type IDs. Resolution: Use LINQ queries to verify exact collection membership after update.

**Uncertainties requiring validation**:
- None blocking - all requirements clear from task description and codebase examination.