### PR TITLE
AG-62 test validation semi

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -161,6 +161,229 @@ public sealed class VehicleModelCommandsIntegrationTests(
             t => !updatedModel.AvailableEngineTypes.Select(x => x.Id).Contains(t.Id));
     }
 
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelIfBrandIdDoesNotExist()
+    {
+        // Arrange - use non-existing BrandId
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var nonExistingBrandId = Guid.NewGuid();
+        var uniqueName = $"Model_{Guid.NewGuid()}";
+
+        var attributeIds = await GetSingleVehicleAttributeIds();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            nonExistingBrandId,
+            type.Id,
+            2005,
+            2010,
+            attributeIds.engineTypes,
+            attributeIds.transmissionTypes,
+            attributeIds.drivetrainTypes,
+            attributeIds.bodyTypes
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert - should fail validation
+        AssertFailureResponse(response);
+
+        // Verify no VehicleModel was persisted with this name
+        var modelInDb = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name.Equals(uniqueName));
+        modelInDb.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelIfTypeIdDoesNotExist()
+    {
+        // Arrange - use non-existing TypeId
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var nonExistingTypeId = Guid.NewGuid();
+        var uniqueName = $"Model_{Guid.NewGuid()}";
+
+        var attributeIds = await GetSingleVehicleAttributeIds();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            brand.Id,
+            nonExistingTypeId,
+            2005,
+            2010,
+            attributeIds.engineTypes,
+            attributeIds.transmissionTypes,
+            attributeIds.drivetrainTypes,
+            attributeIds.bodyTypes
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert - should fail validation
+        AssertFailureResponse(response);
+
+        // Verify no VehicleModel was persisted with this name
+        var modelInDb = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name.Equals(uniqueName));
+        modelInDb.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelIfNameIsDuplicate()
+    {
+        // Arrange - get an existing model name to create a duplicate
+        var existingModelName = await Context.Set<VehicleModel>()
+            .Select(m => m.Name)
+            .FirstAsync();
+
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+
+        var attributeIds = await GetSingleVehicleAttributeIds();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            existingModelName,
+            brand.Id,
+            type.Id,
+            2015,
+            2020,
+            attributeIds.engineTypes,
+            attributeIds.transmissionTypes,
+            attributeIds.drivetrainTypes,
+            attributeIds.bodyTypes
+        );
+
+        var countBefore = await Context.Set<VehicleModel>()
+            .CountAsync(m => m.Name.Equals(existingModelName));
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert - should fail due to duplicate name
+        AssertFailureResponse(response);
+
+        // Verify no additional model was created
+        var countAfter = await Context.Set<VehicleModel>()
+            .CountAsync(m => m.Name.Equals(existingModelName));
+        countAfter.Should().Be(countBefore);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange - get an existing model to update
+        var existingModel = await GetVehicleModelWithAllIncludes();
+
+        var originalEngineTypeIds = existingModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            existingModel.MaximumProductionYear,
+            originalEngineTypeIds.Append(nonExistingEngineTypeId), // Add non-existing ID
+            existingModel.AvailableTransmissionTypes.Select(t => t.Id),
+            existingModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            existingModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert - should fail validation
+        AssertFailureResponse(response);
+
+        // Verify model relationships were not modified
+        var modelAfter = await Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .AsNoTracking()
+            .FirstAsync(m => m.Id.Equals(existingModel.Id));
+
+        modelAfter.AvailableEngineTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_Should_ReplaceRelationshipsEntirely()
+    {
+        // Arrange - get an existing model with relationships
+        var existingModel = await GetVehicleModelWithAllIncludes();
+
+        var originalEngineTypeIds = existingModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+
+        // Get completely different engine types (exclude the current ones)
+        var newEngineTypes = await Context.Set<VehicleEngineType>()
+            .Where(t => !originalEngineTypeIds.Contains(t.Id))
+            .Take(2)
+            .Select(t => t.Id)
+            .ToListAsync();
+
+        newEngineTypes.Should().NotBeEmpty("test database must have additional engine types");
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            existingModel.MaximumProductionYear,
+            newEngineTypes, // Completely new set, excluding old ones
+            existingModel.AvailableTransmissionTypes.Select(t => t.Id),
+            existingModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            existingModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert - should succeed
+        response.IsSuccess.Should().BeTrue();
+        response.Error.Should().Be(Error.None);
+
+        // Verify relationships were completely replaced
+        var modelAfter = await Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .AsNoTracking()
+            .FirstAsync(m => m.Id.Equals(existingModel.Id));
+
+        // Old engine types should be gone
+        foreach (var oldEngineTypeId in originalEngineTypeIds)
+        {
+            modelAfter.AvailableEngineTypes
+                .Should().NotContain(t => t.Id.Equals(oldEngineTypeId));
+        }
+
+        // New engine types should be present
+        foreach (var newEngineTypeId in newEngineTypes)
+        {
+            modelAfter.AvailableEngineTypes
+                .Should().Contain(t => t.Id.Equals(newEngineTypeId));
+        }
+    }
+
+    private async Task<(List<Guid> engineTypes, List<Guid> transmissionTypes, List<Guid> drivetrainTypes, List<Guid> bodyTypes)>
+        GetSingleVehicleAttributeIds()
+    {
+        var engineTypes = await Context.Set<VehicleEngineType>().Take(1).Select(x => x.Id).ToListAsync();
+        var transmissionTypes = await Context.Set<VehicleTransmissionType>().Take(1).Select(x => x.Id).ToListAsync();
+        var drivetrainTypes = await Context.Set<VehicleDrivetrainType>().Take(1).Select(x => x.Id).ToListAsync();
+        var bodyTypes = await Context.Set<VehicleBodyType>().Take(1).Select(x => x.Id).ToListAsync();
+
+        return (engineTypes, transmissionTypes, drivetrainTypes, bodyTypes);
+    }
+
+    private static void AssertFailureResponse(Result response)
+    {
+        response.IsSuccess.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+    }
+
+    private async Task<VehicleModel> GetVehicleModelWithAllIncludes()
+    {
+        return await Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .Include(m => m.AvailableTransmissionTypes)
+            .Include(m => m.AvailableDrivetrainTypes)
+            .Include(m => m.AvailableBodyTypes)
+            .FirstAsync();
+    }
+
     private async Task<CreateVehicleModelCommandRequest> InstantiateValidCreateRequest()
     {
         var brand = await Context.Set<VehicleBrand>().FirstAsync();


### PR DESCRIPTION
Implementation of AG-62

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

1. Review existing test patterns in VehicleModelCommandsIntegrationTests.cs
2. Analyze validators to identify all edge cases not currently covered
3. Examine UpdateVehicleModelCommand to understand relationship replacement behavior
4. Design at least 3 new tests covering realistic domain edge cases
5. Verify test independence and determinism
6. Ensure both Result state and database side effects are asserted
7. Build and run tests to confirm passing

## Overview

Add integration tests to VehicleModelCommandsIntegrationTests.cs covering edge cases for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Focus on: (1) non-existing foreign key references, (2) duplicate name validation, (3) update failure scenarios with non-existing type IDs, (4) relationship replacement verification. All tests will use existing IntegrationTestBase infrastructure, MediatR Sender, real EF Core Context, xUnit, and FluentAssertions without mocks or in-memory database.

## Assumptions and Rules from CLAUDE.md

**From lanos-test skill:**
- Use naming convention: `Method_Scenario_Should_ExpectedOutcome`
- Inherit from IntegrationTestBase with primary constructor
- Send via MediatR Sender, arrange using real Context
- Assert both Result state AND database side effects
- For failures, verify no partial data persisted
- Use Guid.NewGuid() for unique names to ensure determinism
- Never use -uall flag with git status
- Run `dotnet build` and `dotnet test` after implementation

**Assumptions:**
- Name uniqueness is global (not per-brand) based on validator line 38
- Update replaces relationships entirely (UpdateVehicleModelCommand line 57)
- Test database has seeded reference data (brands, types)

**No ambiguous rules identified.**

## Step-by-Step Implementation

1. **Read existing test file completely** to understand helper methods and patterns
- Dependencies: None
- Tools: Read tool

2. **Design 5 new test cases**:
- `Send_CreateRequest_ShouldNot_AddModelIfBrandIdDoesNotExist` - non-existing brand
- `Send_CreateRequest_ShouldNot_AddModelIfTypeIdDoesNotExist` - non-existing type
- `Send_CreateRequest_ShouldNot_AddModelIfNameIsDuplicate` - duplicate name globally
- `Send_UpdateRequest_ShouldNot_UpdateModelIfEngineTypeIdDoesNotExist` - invalid engine type ID
- `Send_UpdateRequest_Should_ReplaceRelationshipsEntirely` - verify replacement not addition

3. **Implement each test** following patterns:
- Arrange: Use Context to fetch/verify existing data
- Act: Send via Sender
- Assert: Result.IsSuccess/Error + database state with FindAsync/Context queries
- For failure cases: verify no new VehicleModel persisted

4. **Build and test**:
- Dependencies: All tests written
- Tools: Bash - `dotnet build tests/IntegrationTests && dotnet test tests/IntegrationTests --filter "FullyQualifiedName~VehicleModelCommands"`

5. **Verify and document**: Confirm all tests pass, deterministic, and independent

## Error Handling and Uncertainties

**Potential issues:**
- Test database may lack sufficient type variety for relationship replacement test → Use OrderBy().Skip(N) to find distinct types
- Duplicate name test needs existing model → Use ModelName constant or query first model
- Non-determinism risk with concurrent test runs → Use unique GUIDs in names

**Mitigation:**
- Query Context first to verify sufficient test data exists
- Use Include() for all relationship assertions
- Follow existing helper method patterns (GetUpdatedModel, etc.)