### PR TITLE
AG-65 post notifications fix manual (enabled pref)

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,7 +102,245 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfBrandIdDoesNotExist()
+    {
+        // Arrange
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var uniqueName = $"Model_{Guid.NewGuid()}";
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            Guid.NewGuid(), // Non-existing brand ID
+            type.Id,
+            2005,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify no model was persisted
+        var persistedModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name == uniqueName);
+        persistedModel
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var uniqueName = $"Model_{Guid.NewGuid()}";
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            brand.Id,
+            Guid.NewGuid(), // Non-existing type ID
+            2005,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify no model was persisted
+        var persistedModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name == uniqueName);
+        persistedModel
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var uniqueName = $"Model_{Guid.NewGuid()}";
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            brand.Id,
+            type.Id,
+            2005,
+            2010,
+            [Guid.NewGuid()], // Non-existing engine type ID
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify no model was persisted
+        var persistedModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name == uniqueName);
+        persistedModel
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfNameAlreadyExists()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>().FirstAsync();
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            existingModel.Name, // Duplicate name
+            brand.Id,
+            type.Id,
+            2005,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify count of models with this name is still 1 (the original)
+        var modelsWithName = await Context.Set<VehicleModel>()
+            .Where(m => m.Name == existingModel.Name)
+            .CountAsync();
+        modelsWithName
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_ModifyRelationshipsIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .Include(m => m.AvailableTransmissionTypes)
+            .Include(m => m.AvailableDrivetrainTypes)
+            .Include(m => m.AvailableBodyTypes)
+            .FirstAsync(m => m.Name.Equals(ModelName));
+
+        var originalEngineTypeIds = existingModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+        var originalTransmissionTypeIds = existingModel.AvailableTransmissionTypes.Select(t => t.Id).ToList();
+        var originalDrivetrainTypeIds = existingModel.AvailableDrivetrainTypes.Select(t => t.Id).ToList();
+        var originalBodyTypeIds = existingModel.AvailableBodyTypes.Select(t => t.Id).ToList();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            existingModel.MaximumProductionYear,
+            [Guid.NewGuid()], // Non-existing engine type ID
+            originalTransmissionTypeIds,
+            originalDrivetrainTypeIds,
+            originalBodyTypeIds
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+
+        // Verify relationships were NOT modified
+        var modelAfterFailedUpdate = await Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .Include(m => m.AvailableTransmissionTypes)
+            .Include(m => m.AvailableDrivetrainTypes)
+            .Include(m => m.AvailableBodyTypes)
+            .FirstAsync(m => m.Id == existingModel.Id);
+
+        modelAfterFailedUpdate.AvailableEngineTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds);
+        modelAfterFailedUpdate.AvailableTransmissionTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalTransmissionTypeIds);
+        modelAfterFailedUpdate.AvailableDrivetrainTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalDrivetrainTypeIds);
+        modelAfterFailedUpdate.AvailableBodyTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalBodyTypeIds);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfModelIdDoesNotExist()
+    {
+        // Arrange
+        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
+        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
+        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            Guid.NewGuid(), // Non-existing model ID
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
         // Assert
         response.Error
             .Should().NotBeNull();

--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -114,117 +114,81 @@ public sealed class VehicleModelCommandsIntegrationTests(
     public async Task Send_CreateRequest_ShouldNot_AddNewModelIfBrandIdDoesNotExist()
     {
         // Arrange
-        var type = await Context.Set<VehicleType>().FirstAsync();
-        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
-        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
-        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
-        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var entities = await GetTestEntities(includeBrand: false);
         var uniqueName = $"Model_{Guid.NewGuid()}";
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             uniqueName,
             Guid.NewGuid(), // Non-existing brand ID
-            type.Id,
+            entities.Type!.Id,
             2005,
             2010,
-            [engineType.Id],
-            [transmissionType.Id],
-            [drivetrainType.Id],
-            [bodyType.Id]
+            [entities.EngineType.Id],
+            [entities.TransmissionType.Id],
+            [entities.DrivetrainType.Id],
+            [entities.BodyType.Id]
         );
 
         // Act
         var response = await Sender.Send(commandRequest);
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.IsSuccess
-            .Should().BeFalse();
-
-        // Verify no model was persisted
-        var persistedModel = await Context.Set<VehicleModel>()
-            .FirstOrDefaultAsync(m => m.Name == uniqueName);
-        persistedModel
-            .Should().BeNull();
+        AssertFailureResponse(response);
+        await AssertModelNotPersisted(uniqueName);
     }
 
     [Fact]
     public async Task Send_CreateRequest_ShouldNot_AddNewModelIfTypeIdDoesNotExist()
     {
         // Arrange
-        var brand = await Context.Set<VehicleBrand>().FirstAsync();
-        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
-        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
-        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
-        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var entities = await GetTestEntities(includeType: false);
         var uniqueName = $"Model_{Guid.NewGuid()}";
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             uniqueName,
-            brand.Id,
+            entities.Brand!.Id,
             Guid.NewGuid(), // Non-existing type ID
             2005,
             2010,
-            [engineType.Id],
-            [transmissionType.Id],
-            [drivetrainType.Id],
-            [bodyType.Id]
+            [entities.EngineType.Id],
+            [entities.TransmissionType.Id],
+            [entities.DrivetrainType.Id],
+            [entities.BodyType.Id]
         );
 
         // Act
         var response = await Sender.Send(commandRequest);
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.IsSuccess
-            .Should().BeFalse();
-
-        // Verify no model was persisted
-        var persistedModel = await Context.Set<VehicleModel>()
-            .FirstOrDefaultAsync(m => m.Name == uniqueName);
-        persistedModel
-            .Should().BeNull();
+        AssertFailureResponse(response);
+        await AssertModelNotPersisted(uniqueName);
     }
 
     [Fact]
     public async Task Send_CreateRequest_ShouldNot_AddNewModelIfEngineTypeIdDoesNotExist()
     {
         // Arrange
-        var brand = await Context.Set<VehicleBrand>().FirstAsync();
-        var type = await Context.Set<VehicleType>().FirstAsync();
-        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
-        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
-        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var entities = await GetTestEntities();
         var uniqueName = $"Model_{Guid.NewGuid()}";
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             uniqueName,
-            brand.Id,
-            type.Id,
+            entities.Brand!.Id,
+            entities.Type!.Id,
             2005,
             2010,
             [Guid.NewGuid()], // Non-existing engine type ID
-            [transmissionType.Id],
-            [drivetrainType.Id],
-            [bodyType.Id]
+            [entities.TransmissionType.Id],
+            [entities.DrivetrainType.Id],
+            [entities.BodyType.Id]
         );
 
         // Act
         var response = await Sender.Send(commandRequest);
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.IsSuccess
-            .Should().BeFalse();
-
-        // Verify no model was persisted
-        var persistedModel = await Context.Set<VehicleModel>()
-            .FirstOrDefaultAsync(m => m.Name == uniqueName);
-        persistedModel
-            .Should().BeNull();
+        AssertFailureResponse(response);
+        await AssertModelNotPersisted(uniqueName);
     }
 
     [Fact]
@@ -232,33 +196,25 @@ public sealed class VehicleModelCommandsIntegrationTests(
     {
         // Arrange
         var existingModel = await Context.Set<VehicleModel>().FirstAsync();
-        var brand = await Context.Set<VehicleBrand>().FirstAsync();
-        var type = await Context.Set<VehicleType>().FirstAsync();
-        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
-        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
-        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
-        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
+        var entities = await GetTestEntities();
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             existingModel.Name, // Duplicate name
-            brand.Id,
-            type.Id,
+            entities.Brand!.Id,
+            entities.Type!.Id,
             2005,
             2010,
-            [engineType.Id],
-            [transmissionType.Id],
-            [drivetrainType.Id],
-            [bodyType.Id]
+            [entities.EngineType.Id],
+            [entities.TransmissionType.Id],
+            [entities.DrivetrainType.Id],
+            [entities.BodyType.Id]
         );
 
         // Act
         var response = await Sender.Send(commandRequest);
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertFailureResponse(response);
 
         // Verify count of models with this name is still 1 (the original)
         var modelsWithName = await Context.Set<VehicleModel>()
@@ -297,10 +253,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
         var response = await Sender.Send(commandRequest);
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertFailureResponse(response);
 
         // Verify relationships were NOT modified
         var modelAfterFailedUpdate = await Context.Set<VehicleModel>()
@@ -324,28 +277,22 @@ public sealed class VehicleModelCommandsIntegrationTests(
     public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfModelIdDoesNotExist()
     {
         // Arrange
-        var transmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync();
-        var drivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync();
-        var bodyType = await Context.Set<VehicleBodyType>().FirstAsync();
-        var engineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        var entities = await GetTestEntities();
 
         var commandRequest = new UpdateVehicleModelCommandRequest(
             Guid.NewGuid(), // Non-existing model ID
             2020,
-            [engineType.Id],
-            [transmissionType.Id],
-            [drivetrainType.Id],
-            [bodyType.Id]
+            [entities.EngineType.Id],
+            [entities.TransmissionType.Id],
+            [entities.DrivetrainType.Id],
+            [entities.BodyType.Id]
         );
 
         // Act
         var response = await Sender.Send(commandRequest);
 
         // Assert
-        response.Error
-            .Should().NotBeNull();
-        response.IsSuccess
-            .Should().BeFalse();
+        AssertFailureResponse(response);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(
@@ -442,5 +389,46 @@ public sealed class VehicleModelCommandsIntegrationTests(
             availableDrivetrainTypes.Select(x => x.Id),
             availableBodyTypes.Select(x => x.Id)
         );
+    }
+
+    private async Task<TestEntities> GetTestEntities(
+        bool includeBrand = true,
+        bool includeType = true)
+    {
+        return new TestEntities
+        {
+            Brand = includeBrand ? await Context.Set<VehicleBrand>().FirstAsync() : null,
+            Type = includeType ? await Context.Set<VehicleType>().FirstAsync() : null,
+            EngineType = await Context.Set<VehicleEngineType>().FirstAsync(),
+            TransmissionType = await Context.Set<VehicleTransmissionType>().FirstAsync(),
+            DrivetrainType = await Context.Set<VehicleDrivetrainType>().FirstAsync(),
+            BodyType = await Context.Set<VehicleBodyType>().FirstAsync()
+        };
+    }
+
+    private async Task AssertModelNotPersisted(string modelName)
+    {
+        var persistedModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name == modelName);
+        persistedModel
+            .Should().BeNull();
+    }
+
+    private static void AssertFailureResponse(Result response)
+    {
+        response.Error
+            .Should().NotBeNull();
+        response.IsSuccess
+            .Should().BeFalse();
+    }
+
+    private record TestEntities
+    {
+        public VehicleBrand? Brand { get; init; }
+        public VehicleType? Type { get; init; }
+        public required VehicleEngineType EngineType { get; init; }
+        public required VehicleTransmissionType TransmissionType { get; init; }
+        public required VehicleDrivetrainType DrivetrainType { get; init; }
+        public required VehicleBodyType BodyType { get; init; }
     }
 }


### PR DESCRIPTION
Implementation of AG-65

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Review existing test patterns in VehicleModelCommandsIntegrationTests.cs
- Identify validation rules from CreateVehicleModelCommandRequestValidator and UpdateVehicleModelCommandRequestValidator
- Understand persistence layer behavior in CreateVehicleModelCommand and UpdateVehicleModelCommand
- Map suggested edge cases to specific test scenarios
- Verify test infrastructure usage (IntegrationTestBase, Sender, Context)
- Ensure tests follow naming convention: Method_Scenario_Should_ExpectedOutcome
- Plan deterministic test data using real seeded entities from Context

## Overview

Add at least 3 meaningful integration tests to VehicleModelCommandsIntegrationTests.cs that validate edge cases for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Tests will cover: (1) creating models with non-existing brand/type IDs should fail without persisting data, (2) creating duplicate model names should fail per global uniqueness constraint, (3) updating models with non-existing type IDs should fail without partial relationship changes. All tests will use existing infrastructure, verify both Result state and database state, and maintain determinism.

## Assumptions and Rules from CLAUDE.md

**Assumptions:**
- Existing seeded test data includes VehicleBrand, VehicleType, and all vehicle type entities
- Name uniqueness validation is global (not per-brand) based on CreateVehicleModelCommandRequestValidator line 39
- UpdateVehicleModelCommand replaces entire type collections (not merges) based on UpdateVehicleModelCommand line 57
- Validation failures return Result.IsSuccess=false with Error containing details

**Project CLAUDE.md Rules (lanos-test skill):**
- Inherit from IntegrationTestBase with primary constructor injection
- Send commands through MediatR Sender (never direct handler invocation)
- Arrange using real Context queries (no mocks, no InMemory provider)
- Assert both Result state AND database side effects
- Use naming: `Send_CreateRequest_ShouldNot_AddNewModelIfBrandIdDoesNotExist`
- For failure cases, verify no data persisted: check Context after failed command
- Use Include() for many-to-many navigation properties
- Generate unique names with `$"Name_{Guid.NewGuid()}"`

**Global CLAUDE.md Rules:**
- Do NOT modify production code unless real defect discovered
- Preserve existing naming/style conventions
- Keep tests deterministic and order-independent

**Ambiguities Resolved:**
- Whether to test validation errors vs persistence exceptions: Test both layers—validators catch most cases, but persistence layer has additional checks (KeyNotFoundException)

## Step-by-Step Implementation

1. **Add test: Create with non-existing BrandId**
- Dependencies: None
- Tools: Edit tool on VehicleModelCommandsIntegrationTests.cs
- Arrange: Use Guid.NewGuid() for brandId, fetch valid typeId and type IDs from Context
- Act: Send CreateVehicleModelCommandRequest with invalid brandId
- Assert: Result.IsSuccess=false, verify no VehicleModel with that name exists in Context

2. **Add test: Create with non-existing TypeId**
- Dependencies: None
- Tools: Edit tool on same file
- Arrange: Fetch valid brandId, use Guid.NewGuid() for typeId, fetch valid type IDs
- Act: Send CreateVehicleModelCommandRequest
- Assert: Result.IsSuccess=false, no persistence

3. **Add test: Create with non-existing EngineTypeId**
- Dependencies: None
- Tools: Edit tool on same file
- Arrange: Valid brand/type, but include Guid.NewGuid() in AvailableEngineTypesIds collection
- Act: Send CreateVehicleModelCommandRequest
- Assert: Result.IsSuccess=false, no persistence

4. **Add test: Create duplicate model name**
- Dependencies: Existing VehicleModel in test database
- Tools: Edit tool on same file
- Arrange: Query existing model name from Context.Set().FirstAsync(), use that name with different brandId
- Act: Send CreateVehicleModelCommandRequest with duplicate name
- Assert: Result.IsSuccess=false (global uniqueness violated)

5. **Add test: Update with non-existing EngineTypeId (no partial changes)**
- Dependencies: Existing VehicleModel
- Tools: Edit tool on same file
- Arrange: Fetch existing model with Include() for all type collections, snapshot current EngineType count, create request with invalid EngineTypeId
- Act: Send UpdateVehicleModelCommandRequest
- Assert: Result.IsSuccess=false, re-query model with Include(), verify AvailableEngineTypes count unchanged and contains same IDs

6. **Add test: Update with non-existing ModelId**
- Dependencies: None
- Tools: Edit tool on same file
- Arrange: Use Guid.NewGuid() for Id, valid type IDs from Context
- Act: Send UpdateVehicleModelCommandRequest
- Assert: Result.IsSuccess=false

7. **Verify build and run tests**
- Dependencies: All tests added
- Tools: Bash tool
- Commands: `dotnet build tests/IntegrationTests`, `dotnet test tests/IntegrationTests --filter "FullyQualifiedName~VehicleModelCommands"`

## Error Handling and Uncertainties

**Potential Issues:**
- Test data seeding may not include sufficient variety of types: Mitigation—use existing InstantiateValidCreateRequest() pattern which already handles this
- Tests may have naming conflicts with const ModelName="test": Mitigation—use unique names with Guid suffix
- Uncertainty about transaction rollback behavior in UpdateVehicleModelCommand: Mitigation—explicitly verify database state unchanged after failures

**Clarification Strategy:**
- If build fails due to namespace changes: Check recent commits for API changes
- If tests fail unexpectedly: Read actual error messages and validator implementation to understand business rules
- If seeded data insufficient: Add helper methods following InstantiateValidCreateRequest() pattern