### PR TITLE
AG-69 extra fixes - manual

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,182 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelIfBrandIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingBrandId = Guid.NewGuid();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var uniqueName = $"TestModel_{Guid.NewGuid()}";
+
+        var (engineTypes, transmissionTypes, drivetrainTypes, bodyTypes) = await GetVehicleTypeIdsAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            nonExistingBrandId,
+            type.Id,
+            2000,
+            2010,
+            engineTypes,
+            transmissionTypes,
+            drivetrainTypes,
+            bodyTypes
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+
+        // Verify no model was persisted
+        var persistedModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name == uniqueName);
+        persistedModel
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddModelIfNameAlreadyExists()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>().FirstAsync();
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+
+        var (engineTypes, transmissionTypes, drivetrainTypes, bodyTypes) = await GetVehicleTypeIdsAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            existingModel.Name, // Duplicate name
+            brand.Id,
+            type.Id,
+            2000,
+            2010,
+            engineTypes,
+            transmissionTypes,
+            drivetrainTypes,
+            bodyTypes
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var model = await LoadModelWithRelationshipsAsync();
+        var originalTypeIds = ExtractRelationshipIds(model);
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            model.Id,
+            model.MaximumProductionYear,
+            originalTypeIds.engineTypes.Append(nonExistingEngineTypeId), // Invalid ID mixed in
+            originalTypeIds.transmissionTypes,
+            originalTypeIds.drivetrainTypes,
+            originalTypeIds.bodyTypes
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+
+        // Reload model and verify relationships are unchanged
+        var reloadedModel = await LoadModelWithRelationshipsAsync(model.Id);
+        AssertRelationshipsUnchanged(reloadedModel, originalTypeIds);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateIfBodyTypeIdDoesNotExist()
+    {
+        // Arrange
+        var model = await LoadModelWithRelationshipsAsync();
+        var originalTypeIds = ExtractRelationshipIds(model);
+        var nonExistingBodyTypeId = Guid.NewGuid();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            model.Id,
+            model.MaximumProductionYear,
+            originalTypeIds.engineTypes,
+            originalTypeIds.transmissionTypes,
+            originalTypeIds.drivetrainTypes,
+            originalTypeIds.bodyTypes.Append(nonExistingBodyTypeId) // Invalid ID mixed in
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+
+        // Reload model and verify relationships are unchanged
+        var reloadedModel = await LoadModelWithRelationshipsAsync(model.Id);
+        AssertRelationshipsUnchanged(reloadedModel, originalTypeIds);
+    }
+
+    private async Task<(List<Guid> engineTypes, List<Guid> transmissionTypes, List<Guid> drivetrainTypes, List<Guid> bodyTypes)> GetVehicleTypeIdsAsync()
+    {
+        var engineTypes = await Context.Set<VehicleEngineType>().Take(1).Select(x => x.Id).ToListAsync();
+        var transmissionTypes = await Context.Set<VehicleTransmissionType>().Take(1).Select(x => x.Id).ToListAsync();
+        var drivetrainTypes = await Context.Set<VehicleDrivetrainType>().Take(1).Select(x => x.Id).ToListAsync();
+        var bodyTypes = await Context.Set<VehicleBodyType>().Take(1).Select(x => x.Id).ToListAsync();
+        return (engineTypes, transmissionTypes, drivetrainTypes, bodyTypes);
+    }
+
+    private async Task<VehicleModel> LoadModelWithRelationshipsAsync(Guid? modelId = null)
+    {
+        var query = Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .Include(m => m.AvailableTransmissionTypes)
+            .Include(m => m.AvailableDrivetrainTypes)
+            .Include(m => m.AvailableBodyTypes);
+
+        return modelId.HasValue
+            ? await query.FirstAsync(m => m.Id == modelId.Value)
+            : await query.FirstAsync();
+    }
+
+    private (List<Guid> engineTypes, List<Guid> transmissionTypes, List<Guid> drivetrainTypes, List<Guid> bodyTypes) ExtractRelationshipIds(VehicleModel model) =>
+        (
+            model.AvailableEngineTypes.Select(x => x.Id).ToList(),
+            model.AvailableTransmissionTypes.Select(x => x.Id).ToList(),
+            model.AvailableDrivetrainTypes.Select(x => x.Id).ToList(),
+            model.AvailableBodyTypes.Select(x => x.Id).ToList()
+        );
+
+    private void AssertRelationshipsUnchanged(
+        VehicleModel model,
+        (List<Guid> engineTypes, List<Guid> transmissionTypes, List<Guid> drivetrainTypes, List<Guid> bodyTypes) expectedTypeIds)
+    {
+        model.AvailableEngineTypes.Select(x => x.Id)
+            .Should().BeEquivalentTo(expectedTypeIds.engineTypes);
+        model.AvailableTransmissionTypes.Select(x => x.Id)
+            .Should().BeEquivalentTo(expectedTypeIds.transmissionTypes);
+        model.AvailableDrivetrainTypes.Select(x => x.Id)
+            .Should().BeEquivalentTo(expectedTypeIds.drivetrainTypes);
+        model.AvailableBodyTypes.Select(x => x.Id)
+            .Should().BeEquivalentTo(expectedTypeIds.bodyTypes);
+    }
+
+    private void AssertFailureResponse<T>(Result<T> response)
+    {
+        response.Error.Should().NotBe(Error.None);
+        response.IsSuccess.Should().BeFalse();
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(

--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -118,7 +118,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
         var type = await Context.Set<VehicleType>().FirstAsync();
         var uniqueName = $"TestModel_{Guid.NewGuid()}";
 
-        var (engineTypes, transmissionTypes, drivetrainTypes, bodyTypes) = await GetVehicleTypeIdsAsync();
+        var typeIds = await GetVehicleTypeIdsAsync();
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             uniqueName,
@@ -126,17 +126,14 @@ public sealed class VehicleModelCommandsIntegrationTests(
             type.Id,
             2000,
             2010,
-            engineTypes,
-            transmissionTypes,
-            drivetrainTypes,
-            bodyTypes
+            typeIds.EngineTypes,
+            typeIds.TransmissionTypes,
+            typeIds.DrivetrainTypes,
+            typeIds.BodyTypes
         );
 
-        // Act
-        var response = await Sender.Send(commandRequest);
-
-        // Assert
-        AssertFailureResponse(response);
+        // Act & Assert
+        await SendCommandAndAssertFailureAsync<Guid>(commandRequest);
 
         // Verify no model was persisted
         var persistedModel = await Context.Set<VehicleModel>()
@@ -153,7 +150,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
         var brand = await Context.Set<VehicleBrand>().FirstAsync();
         var type = await Context.Set<VehicleType>().FirstAsync();
 
-        var (engineTypes, transmissionTypes, drivetrainTypes, bodyTypes) = await GetVehicleTypeIdsAsync();
+        var typeIds = await GetVehicleTypeIdsAsync();
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             existingModel.Name, // Duplicate name
@@ -161,44 +158,38 @@ public sealed class VehicleModelCommandsIntegrationTests(
             type.Id,
             2000,
             2010,
-            engineTypes,
-            transmissionTypes,
-            drivetrainTypes,
-            bodyTypes
+            typeIds.EngineTypes,
+            typeIds.TransmissionTypes,
+            typeIds.DrivetrainTypes,
+            typeIds.BodyTypes
         );
 
-        // Act
-        var response = await Sender.Send(commandRequest);
-
-        // Assert
-        AssertFailureResponse(response);
+        // Act & Assert
+        await SendCommandAndAssertFailureAsync<Guid>(commandRequest);
     }
 
     [Fact]
     public async Task Send_UpdateRequest_ShouldNot_UpdateIfEngineTypeIdDoesNotExist()
     {
         // Arrange
-        var model = await LoadModelWithRelationshipsAsync();
+        var model = await GetUpdatedModel();
         var originalTypeIds = ExtractRelationshipIds(model);
         var nonExistingEngineTypeId = Guid.NewGuid();
 
         var commandRequest = new UpdateVehicleModelCommandRequest(
             model.Id,
             model.MaximumProductionYear,
-            originalTypeIds.engineTypes.Append(nonExistingEngineTypeId), // Invalid ID mixed in
-            originalTypeIds.transmissionTypes,
-            originalTypeIds.drivetrainTypes,
-            originalTypeIds.bodyTypes
+            originalTypeIds.EngineTypes.Append(nonExistingEngineTypeId), // Invalid ID mixed in
+            originalTypeIds.TransmissionTypes,
+            originalTypeIds.DrivetrainTypes,
+            originalTypeIds.BodyTypes
         );
 
-        // Act
-        var response = await Sender.Send(commandRequest);
-
-        // Assert
-        AssertFailureResponse(response);
+        // Act & Assert
+        await SendCommandAndAssertFailureAsync<bool>(commandRequest);
 
         // Reload model and verify relationships are unchanged
-        var reloadedModel = await LoadModelWithRelationshipsAsync(model.Id);
+        var reloadedModel = await GetUpdatedModel(model.Id);
         AssertRelationshipsUnchanged(reloadedModel, originalTypeIds);
     }
 
@@ -206,77 +197,83 @@ public sealed class VehicleModelCommandsIntegrationTests(
     public async Task Send_UpdateRequest_ShouldNot_UpdateIfBodyTypeIdDoesNotExist()
     {
         // Arrange
-        var model = await LoadModelWithRelationshipsAsync();
+        var model = await GetUpdatedModel();
         var originalTypeIds = ExtractRelationshipIds(model);
         var nonExistingBodyTypeId = Guid.NewGuid();
 
         var commandRequest = new UpdateVehicleModelCommandRequest(
             model.Id,
             model.MaximumProductionYear,
-            originalTypeIds.engineTypes,
-            originalTypeIds.transmissionTypes,
-            originalTypeIds.drivetrainTypes,
-            originalTypeIds.bodyTypes.Append(nonExistingBodyTypeId) // Invalid ID mixed in
+            originalTypeIds.EngineTypes,
+            originalTypeIds.TransmissionTypes,
+            originalTypeIds.DrivetrainTypes,
+            originalTypeIds.BodyTypes.Append(nonExistingBodyTypeId) // Invalid ID mixed in
         );
 
-        // Act
-        var response = await Sender.Send(commandRequest);
-
-        // Assert
-        AssertFailureResponse(response);
+        // Act & Assert
+        await SendCommandAndAssertFailureAsync<bool>(commandRequest);
 
         // Reload model and verify relationships are unchanged
-        var reloadedModel = await LoadModelWithRelationshipsAsync(model.Id);
+        var reloadedModel = await GetUpdatedModel(model.Id);
         AssertRelationshipsUnchanged(reloadedModel, originalTypeIds);
     }
 
-    private async Task<(List<Guid> engineTypes, List<Guid> transmissionTypes, List<Guid> drivetrainTypes, List<Guid> bodyTypes)> GetVehicleTypeIdsAsync()
+    /// <summary>
+    /// Record type for vehicle type IDs to improve code clarity over tuple returns
+    /// </summary>
+    private record VehicleTypeIds(
+        List<Guid> EngineTypes,
+        List<Guid> TransmissionTypes,
+        List<Guid> DrivetrainTypes,
+        List<Guid> BodyTypes);
+
+    /// <summary>
+    /// Retrieves one ID per vehicle type for simple negative test scenarios.
+    /// Uses Take(1) for minimal test data setup, unlike InstantiateValidCreateRequest()
+    /// which retrieves First and Last IDs (2 per type) for comprehensive positive test coverage.
+    /// </summary>
+    private async Task<VehicleTypeIds> GetVehicleTypeIdsAsync()
     {
         var engineTypes = await Context.Set<VehicleEngineType>().Take(1).Select(x => x.Id).ToListAsync();
         var transmissionTypes = await Context.Set<VehicleTransmissionType>().Take(1).Select(x => x.Id).ToListAsync();
         var drivetrainTypes = await Context.Set<VehicleDrivetrainType>().Take(1).Select(x => x.Id).ToListAsync();
         var bodyTypes = await Context.Set<VehicleBodyType>().Take(1).Select(x => x.Id).ToListAsync();
-        return (engineTypes, transmissionTypes, drivetrainTypes, bodyTypes);
+        return new VehicleTypeIds(engineTypes, transmissionTypes, drivetrainTypes, bodyTypes);
     }
 
-    private async Task<VehicleModel> LoadModelWithRelationshipsAsync(Guid? modelId = null)
-    {
-        var query = Context.Set<VehicleModel>()
-            .Include(m => m.AvailableEngineTypes)
-            .Include(m => m.AvailableTransmissionTypes)
-            .Include(m => m.AvailableDrivetrainTypes)
-            .Include(m => m.AvailableBodyTypes);
-
-        return modelId.HasValue
-            ? await query.FirstAsync(m => m.Id == modelId.Value)
-            : await query.FirstAsync();
-    }
-
-    private (List<Guid> engineTypes, List<Guid> transmissionTypes, List<Guid> drivetrainTypes, List<Guid> bodyTypes) ExtractRelationshipIds(VehicleModel model) =>
-        (
+    private VehicleTypeIds ExtractRelationshipIds(VehicleModel model) =>
+        new VehicleTypeIds(
             model.AvailableEngineTypes.Select(x => x.Id).ToList(),
             model.AvailableTransmissionTypes.Select(x => x.Id).ToList(),
             model.AvailableDrivetrainTypes.Select(x => x.Id).ToList(),
             model.AvailableBodyTypes.Select(x => x.Id).ToList()
         );
 
-    private void AssertRelationshipsUnchanged(
-        VehicleModel model,
-        (List<Guid> engineTypes, List<Guid> transmissionTypes, List<Guid> drivetrainTypes, List<Guid> bodyTypes) expectedTypeIds)
+    private void AssertRelationshipsUnchanged(VehicleModel model, VehicleTypeIds expectedTypeIds)
     {
         model.AvailableEngineTypes.Select(x => x.Id)
-            .Should().BeEquivalentTo(expectedTypeIds.engineTypes);
+            .Should().BeEquivalentTo(expectedTypeIds.EngineTypes);
         model.AvailableTransmissionTypes.Select(x => x.Id)
-            .Should().BeEquivalentTo(expectedTypeIds.transmissionTypes);
+            .Should().BeEquivalentTo(expectedTypeIds.TransmissionTypes);
         model.AvailableDrivetrainTypes.Select(x => x.Id)
-            .Should().BeEquivalentTo(expectedTypeIds.drivetrainTypes);
+            .Should().BeEquivalentTo(expectedTypeIds.DrivetrainTypes);
         model.AvailableBodyTypes.Select(x => x.Id)
-            .Should().BeEquivalentTo(expectedTypeIds.bodyTypes);
+            .Should().BeEquivalentTo(expectedTypeIds.BodyTypes);
+    }
+
+    /// <summary>
+    /// Helper method to reduce duplication in negative test cases.
+    /// Sends a command and asserts it fails with the expected error response.
+    /// </summary>
+    private async Task SendCommandAndAssertFailureAsync<T>(object command)
+    {
+        var response = await Sender.Send(command);
+        AssertFailureResponse<T>((Result<T>)response);
     }
 
     private void AssertFailureResponse<T>(Result<T> response)
     {
-        response.Error.Should().NotBe(Error.None);
+        response.Error.Should().NotBeNull();
         response.IsSuccess.Should().BeFalse();
     }
 
@@ -309,14 +306,17 @@ public sealed class VehicleModelCommandsIntegrationTests(
             t => !updatedModel.AvailableDrivetrainTypes.Select(x => x.Id).Contains(t.Id));
     }
 
-    private async Task<VehicleModel> GetUpdatedModel()
+    private async Task<VehicleModel> GetUpdatedModel(Guid? modelId = null)
     {
-        return await Context.Set<VehicleModel>()
+        var query = Context.Set<VehicleModel>()
             .Include(model => model.AvailableDrivetrainTypes)
             .Include(model => model.AvailableEngineTypes)
             .Include(model => model.AvailableBodyTypes)
-            .Include(model => model.AvailableTransmissionTypes)
-            .FirstAsync(m => m.Name.Equals(ModelName));
+            .Include(model => model.AvailableTransmissionTypes);
+
+        return modelId.HasValue
+            ? await query.FirstAsync(m => m.Id == modelId.Value)
+            : await query.FirstAsync(m => m.Name.Equals(ModelName));
     }
 
     private async Task<VehicleBodyType> GetNewBodyType(VehicleModel updatedModel)


### PR DESCRIPTION
Implementation of AG-69

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Review existing test coverage in VehicleModelCommandsIntegrationTests.cs
- Analyze validator rules to identify edge cases not currently tested
- Understand entity relationships and how updates affect them
- Identify realistic domain scenarios that could cause failures
- Design tests that verify both Result state and database side effects
- Ensure tests are deterministic and use real seeded data
- Follow existing naming conventions and test patterns

## Overview

Add at least 3 new integration tests to VehicleModelCommandsIntegrationTests.cs that validate edge cases for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Focus on realistic failure scenarios: non-existing foreign keys, duplicate names, invalid type IDs during updates, and relationship replacement behavior. All tests will use the existing IntegrationTestBase infrastructure with real PostgreSQL database, MediatR Sender, and FluentAssertions.

## Assumptions and Rules from CLAUDE.md

**Assumptions:**
- Test database has seeded reference data for VehicleBrand, VehicleType, and all type entities
- Duplicate name validation is global (confirmed from CreateVehicleModelCommandRequestValidator line 39)
- Update relationships are replaced, not merged (confirmed from existing test lines 123-126)
- Validators run before handlers, so validation failures prevent persistence

**Rules from lanos-test skill:**
1. Inherit from IntegrationTestBase with primary constructor injection
2. Use Sender (MediatR) to send commands
3. Arrange using Context to fetch real entities, no mocks
4. Assert both Result state (IsSuccess, Error) and database side effects
5. For failures, verify no partial data was persisted
6. Use naming convention: Method_Scenario_Should_ExpectedOutcome
7. Keep tests deterministic: use unique names like $"Name_{Guid.NewGuid()}"
8. Use Include() for loading navigation properties when verifying relationships
9. Run dotnet build and dotnet test after implementation

**No ambiguous or missing rules** - all guidelines are clear from the skill documentation.

## Step-by-Step Implementation

1. **Add test: Create with non-existing BrandId should fail and not persist**
- Dependencies: None
- Tools: Edit VehicleModelCommandsIntegrationTests.cs
- Create request with Guid.NewGuid() for BrandId (guaranteed non-existing), valid other fields
- Assert Result.IsSuccess = false, Error is not None
- Query database to verify no VehicleModel with that name was created

2. **Add test: Create with non-existing TypeId should fail and not persist**
- Dependencies: None
- Tools: Edit VehicleModelCommandsIntegrationTests.cs
- Create request with Guid.NewGuid() for TypeId, valid BrandId
- Assert Result.IsSuccess = false
- Verify no VehicleModel was persisted

3. **Add test: Create with duplicate name should fail**
- Dependencies: None
- Tools: Edit VehicleModelCommandsIntegrationTests.cs
- Fetch existing VehicleModel name from Context
- Attempt to create new model with same name but different brand
- Assert validation failure (IsSuccess = false)

4. **Add test: Update with non-existing EngineType ID should fail without changing DB**
- Dependencies: None
- Tools: Edit VehicleModelCommandsIntegrationTests.cs
- Fetch existing model with relationships using Include()
- Create update request with one non-existing EngineType ID mixed with valid IDs
- Assert Result.IsSuccess = false
- Reload model with Include() and verify relationships unchanged from original

5. **Build and test verification**
- Dependencies: Steps 1-4 complete
- Tools: Bash (dotnet build, dotnet test)
- Run: dotnet build tests/IntegrationTests
- Run: dotnet test tests/IntegrationTests --filter "FullyQualifiedName~VehicleModelCommands"
- Verify all new tests pass

## Error Handling and Uncertainties

**Potential Issues:**
1. Test data availability - If seeded data lacks diversity, some tests may need adjustment
- Mitigation: Use FirstAsync() pattern already successful in existing tests

2. Naming conflicts - Using static names could conflict with seeded data
- Mitigation: Use unique names with Guid suffix per lanos-test conventions

3. Validator vs DB constraint timing - Need to confirm validators catch issues before DB
- Expected: Validators fail before handler executes per MediatR pipeline

All uncertainties are manageable within existing test infrastructure. No user clarification needed.