### PR TITLE
2247 test semi

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,181 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelWhenBrandIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingBrandId = Guid.NewGuid();
+        var (type, engineType, bodyType, transmissionType, drivetrainType) = await GetVehicleOptionTypesAsync();
+
+        const string testModelName = "NonExistingBrandModel";
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            testModelName,
+            nonExistingBrandId,
+            type.Id,
+            2005,
+            2010,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelNotPersistedAsync(testModelName);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelWhenEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingEngineTypeId = Guid.NewGuid();
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var (type, _, bodyType, transmissionType, drivetrainType) = await GetVehicleOptionTypesAsync();
+
+        const string testModelName = "NonExistingEngineTypeModel";
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            testModelName,
+            brand.Id,
+            type.Id,
+            2005,
+            2010,
+            [nonExistingEngineTypeId],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelNotPersistedAsync(testModelName);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelWhenNameAlreadyExists()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>().FirstAsync(m => m.Name.Equals(ModelName));
+        var brand = await Context.Set<VehicleBrand>().FirstAsync(b => b.Id != existingModel.BrandId);
+        var (type, engineType, bodyType, transmissionType, drivetrainType) = await GetVehicleOptionTypesAsync();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            ModelName, // Using existing model name
+            brand.Id,  // But different brand
+            type.Id,
+            2015,
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var modelsWithSameName = await Context.Set<VehicleModel>()
+            .Where(m => m.Name.Equals(ModelName))
+            .ToListAsync();
+
+        // Assert
+        AssertFailureResponse(response);
+        modelsWithSameName.Count
+            .Should().Be(1, "only the original model should exist, duplicate should not be persisted");
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateWhenModelIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingModelId = Guid.NewGuid();
+        var (_, engineType, bodyType, transmissionType, drivetrainType) = await GetVehicleOptionTypesAsync();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            nonExistingModelId,
+            2020,
+            [engineType.Id],
+            [transmissionType.Id],
+            [drivetrainType.Id],
+            [bodyType.Id]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelWhenBodyTypeIdDoesNotExist()
+    {
+        // Arrange
+        var updatedModel = await GetUpdatedModel();
+        var nonExistingBodyTypeId = Guid.NewGuid();
+        var originalBodyTypeIds = updatedModel.AvailableBodyTypes.Select(t => t.Id).ToList();
+        var originalMaxYear = updatedModel.MaximumProductionYear;
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            updatedModel.Id,
+            updatedModel.MinimalProductionYear + 5, // Try to change max year
+            updatedModel.AvailableEngineTypes.Select(t => t.Id),
+            updatedModel.AvailableTransmissionTypes.Select(t => t.Id),
+            updatedModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            [nonExistingBodyTypeId] // Invalid body type ID
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var modelAfterFailedUpdate = await GetUpdatedModel();
+
+        // Assert
+        AssertFailureResponse(response);
+
+        // Verify no changes were persisted
+        modelAfterFailedUpdate.MaximumProductionYear
+            .Should().Be(originalMaxYear, "production year should not change when validation fails");
+        modelAfterFailedUpdate.AvailableBodyTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalBodyTypeIds, "body types should remain unchanged when validation fails");
+    }
+
+    private async Task<(VehicleType type, VehicleEngineType engineType, VehicleBodyType bodyType,
+        VehicleTransmissionType transmissionType, VehicleDrivetrainType drivetrainType)> GetVehicleOptionTypesAsync()
+    {
+        return (
+            await Context.Set<VehicleType>().FirstAsync(),
+            await Context.Set<VehicleEngineType>().FirstAsync(),
+            await Context.Set<VehicleBodyType>().FirstAsync(),
+            await Context.Set<VehicleTransmissionType>().FirstAsync(),
+            await Context.Set<VehicleDrivetrainType>().FirstAsync()
+        );
+    }
+
+    private static void AssertFailureResponse<T>(Result<T> response)
+    {
+        response.IsSuccess.Should().BeFalse();
+        response.Error.Should().NotBe(Error.None);
+    }
+
+    private async Task AssertModelNotPersistedAsync(string modelName)
+    {
+        var persistedModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name.Equals(modelName));
+        persistedModel.Should().BeNull();
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(


### PR DESCRIPTION
Implementation of 2247

Add meaningful integration test coverage for VehicleModel command behavior.
Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.
Requirements:
- Do not introduce mocks or an in-memory database.

- Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.

- Add at least 3 new integration tests.

- Cover realistic domain/application edge cases, not only empty Guid validation.

- Verify both Result state and persisted database state where relevant.

- Prefer reusing seeded reference data from the real test database.

- Keep the tests deterministic and independent from execution order.

- Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.

- Preserve the project’s current naming/style conventions.

Suggested cases to consider:
- creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;

- creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;

- updating a model with non-existing related type IDs should fail without partially changing existing relationships;

- updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Review existing test patterns in VehicleModelCommandsIntegrationTests.cs
- Analyze validation rules in CreateVehicleModelCommandRequestValidator and UpdateVehicleModelCommandRequestValidator
- Understand error handling in command handlers (KeyNotFoundException → NotFound Result)
- Identify seeded reference data available in test database
- Design tests covering suggested edge cases: non-existing IDs, duplicate names, partial update failures
- Ensure deterministic, order-independent test execution
- Verify both Result state and database state in assertions

## Overview

Add at least 3 meaningful integration tests to VehicleModelCommandsIntegrationTests.cs that validate edge cases for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Tests will use existing patterns (IntegrationTestBase, MediatR Sender, EF Core Context, xUnit, FluentAssertions) without introducing mocks or in-memory database. Focus on realistic domain/application edge cases beyond empty Guid validation, verifying both Result state and persisted database state.

## Assumptions and Rules from CLAUDE.md

No project CLAUDE.md or global CLAUDE.md found, so relying on:

**Assumptions:**
- Test database has seeded VehicleBrand, VehicleType, and related type entities (VehicleEngineType, VehicleBodyType, etc.)
- Name uniqueness validation is global, not per-brand (confirmed in CreateVehicleModelCommandRequestValidator line 35-41)
- FluentValidation runs before handlers, preventing invalid data from reaching persistence layer
- EF Core transactions ensure atomicity (validation failures don't persist partial data)

**Inferred Rules from Codebase:**
- Follow Arrange/Act/Assert pattern (from existing tests)
- Use descriptive test names with Should/ShouldNot convention
- Use FluentAssertions for all assertions
- Verify both Result.IsSuccess/Error and database state with Context.FindAsync or Context.Set().FirstAsync
- Create helper methods for complex setup (e.g., InstantiateValidCreateRequest pattern)
- Use const string for test data names to enable deterministic cleanup/reuse
- Use Guid.NewGuid() for non-existing ID tests to avoid collision with real data

## Step-by-Step Implementation

1. **Test: Create with non-existing BrandId should fail and not persist**
- Dependencies: Understand validator checks BrandId existence (CreateVehicleModelCommandRequestValidator line 112-116)
- Tools/Files: Edit VehicleModelCommandsIntegrationTests.cs
- Arrange: Create request with Guid.NewGuid() as BrandId, valid other fields
- Act: Send command via Sender
- Assert: Result.IsSuccess is false, Result.Error is not None, verify no VehicleModel persisted with that name

2. **Test: Create with non-existing EngineType ID should fail and not persist**
- Dependencies: Validator checks collection ID existence (CreateVehicleModelCommandRequestValidator line 70-73)
- Tools/Files: Edit VehicleModelCommandsIntegrationTests.cs
- Arrange: Create request with valid brand/type but include Guid.NewGuid() in AvailableEngineTypesIds
- Act: Send command via Sender
- Assert: Result.IsSuccess is false, Result.Error is not None, verify no VehicleModel persisted

3. **Test: Create with duplicate model name should fail**
- Dependencies: Name uniqueness check (CreateVehicleModelCommandRequestValidator line 34-41)
- Tools/Files: Edit VehicleModelCommandsIntegrationTests.cs
- Arrange: Query existing VehicleModel name from Context, create request with same name but different brand
- Act: Send command via Sender
- Assert: Result.IsSuccess is false, Result.Error contains message about existing name

4. **Test: Update with non-existing model ID should return NotFound**
- Dependencies: UpdateHandler catches KeyNotFoundException (UpdateVehicleModelCommandRequestHandler line 19-22)
- Tools/Files: Edit VehicleModelCommandsIntegrationTests.cs
- Arrange: Create UpdateVehicleModelCommandRequest with Guid.NewGuid() as Id, valid other fields
- Act: Send command via Sender
- Assert: Result.IsSuccess is false, Result.Error type is NotFound

5. **Test: Update with non-existing BodyType ID should fail without persisting changes**
- Dependencies: Validator checks BodyType ID existence (UpdateVehicleModelCommandRequestValidator line 29-32)
- Tools/Files: Edit VehicleModelCommandsIntegrationTests.cs
- Arrange: Get existing model via GetUpdatedModel(), create update request with Guid.NewGuid() in AvailableBodyTypesIds
- Act: Send command, query model again from database
- Assert: Result.IsSuccess is false, verify model's AvailableBodyTypes unchanged in database

6. **Verify test independence and determinism**
- Dependencies: None
- Tools/Files: Review all new tests
- Check: Each test creates unique test data or uses non-colliding IDs (Guid.NewGuid())
- Check: Tests don't depend on execution order
- Check: Cleanup not needed (failed creates don't persist, updates to non-existing IDs don't affect DB)

## Error Handling and Uncertainties

**Potential Issues:**
- If test database doesn't have sufficient seeded data (multiple brands, types, etc.), tests may fail on FirstAsync() calls. Mitigation: Use existing patterns like InstantiateValidCreateRequest() which safely queries seeded data.
- Name uniqueness is global, not per-brand, which might seem unintuitive but is confirmed by validator implementation. Tests will validate this existing behavior.
- FluentValidation failures vs. persistence layer KeyNotFoundExceptions have different error structures. Tests will verify both paths appropriately.

**Clarification Strategy:**
- If a test reveals unexpected behavior (e.g., duplicate names allowed), document as finding rather than modifying production code unless it's clearly a bug blocking test validity.