### PR TITLE
AG-71 test12343

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -161,6 +161,188 @@ public sealed class VehicleModelCommandsIntegrationTests(
             t => !updatedModel.AvailableEngineTypes.Select(x => x.Id).Contains(t.Id));
     }
 
+    [Fact]
+    public async Task Send_CreateRequestWithNonExistingBrandId_ShouldNot_AddNewModel()
+    {
+        // Arrange
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var (engineTypeId, transmissionTypeId, drivetrainTypeId, bodyTypeId) = await GetVehicleTypeIds();
+
+        var uniqueName = GenerateUniqueModelName();
+        var nonExistingBrandId = Guid.NewGuid();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            nonExistingBrandId,
+            type.Id,
+            2005,
+            2010,
+            [engineTypeId],
+            [transmissionTypeId],
+            [drivetrainTypeId],
+            [bodyTypeId]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelNotCreated(uniqueName);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequestWithNonExistingTypeId_ShouldNot_AddNewModel()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var (engineTypeId, transmissionTypeId, drivetrainTypeId, bodyTypeId) = await GetVehicleTypeIds();
+
+        var uniqueName = GenerateUniqueModelName();
+        var nonExistingTypeId = Guid.NewGuid();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            brand.Id,
+            nonExistingTypeId,
+            2005,
+            2010,
+            [engineTypeId],
+            [transmissionTypeId],
+            [drivetrainTypeId],
+            [bodyTypeId]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelNotCreated(uniqueName);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequestWithNonExistingEngineTypeId_ShouldNot_AddNewModel()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var (_, transmissionTypeId, drivetrainTypeId, bodyTypeId) = await GetVehicleTypeIds();
+
+        var uniqueName = GenerateUniqueModelName();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            uniqueName,
+            brand.Id,
+            type.Id,
+            2005,
+            2010,
+            [nonExistingEngineTypeId],
+            [transmissionTypeId],
+            [drivetrainTypeId],
+            [bodyTypeId]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+        await AssertModelNotCreated(uniqueName);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequestWithDuplicateName_ShouldNot_AddNewModel()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>().FirstAsync();
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var (engineTypeId, transmissionTypeId, drivetrainTypeId, bodyTypeId) = await GetVehicleTypeIds();
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            existingModel.Name,
+            brand.Id,
+            type.Id,
+            2005,
+            2010,
+            [engineTypeId],
+            [transmissionTypeId],
+            [drivetrainTypeId],
+            [bodyTypeId]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+
+        var modelCount = await Context.Set<VehicleModel>()
+            .CountAsync(m => m.Name == existingModel.Name);
+        modelCount
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequestWithNonExistingEngineTypeId_ShouldNot_UpdateModel()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .FirstAsync(m => m.Name.Equals(ModelName));
+
+        var originalEngineTypeIds = existingModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            existingModel.MaximumProductionYear,
+            [nonExistingEngineTypeId],
+            existingModel.AvailableTransmissionTypes.Select(t => t.Id),
+            existingModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            existingModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        AssertFailureResponse(response);
+
+        var unchangedModel = await Context.Set<VehicleModel>()
+            .Include(m => m.AvailableEngineTypes)
+            .FirstAsync(m => m.Id == existingModel.Id);
+
+        unchangedModel.AvailableEngineTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds);
+    }
+
+    private async Task<(Guid engineTypeId, Guid transmissionTypeId, Guid drivetrainTypeId, Guid bodyTypeId)> GetVehicleTypeIds()
+    {
+        var engineTypeId = (await Context.Set<VehicleEngineType>().FirstAsync()).Id;
+        var transmissionTypeId = (await Context.Set<VehicleTransmissionType>().FirstAsync()).Id;
+        var drivetrainTypeId = (await Context.Set<VehicleDrivetrainType>().FirstAsync()).Id;
+        var bodyTypeId = (await Context.Set<VehicleBodyType>().FirstAsync()).Id;
+        return (engineTypeId, transmissionTypeId, drivetrainTypeId, bodyTypeId);
+    }
+
+    private static void AssertFailureResponse<T>(Result<T> response)
+    {
+        response.Error.Should().NotBeNull();
+        response.IsSuccess.Should().BeFalse();
+    }
+
+    private async Task AssertModelNotCreated(string modelName)
+    {
+        var model = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name == modelName);
+        model.Should().BeNull();
+    }
+
+    private static string GenerateUniqueModelName() => $"TestModel_{Guid.NewGuid()}";
+
     private async Task<CreateVehicleModelCommandRequest> InstantiateValidCreateRequest()
     {
         var brand = await Context.Set<VehicleBrand>().FirstAsync();


### PR DESCRIPTION
Implementation of AG-71

Add meaningful integration test coverage for VehicleModel command behavior.

Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.

Requirements:

# Do not introduce mocks or an in-memory database.
# Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
# Add at least 3 new integration tests.
# Cover realistic domain/application edge cases, not only empty Guid validation.
# Verify both Result state and persisted database state where relevant.
# Prefer reusing seeded reference data from the real test database.
# Keep the tests deterministic and independent from execution order.
# Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
# Preserve the project’s current naming/style conventions.

Suggested cases to consider:

* creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
* creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
* updating a model with non-existing related type IDs should fail without partially changing existing relationships;
* updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Review existing VehicleModelCommandsIntegrationTests.cs patterns and naming conventions
- Identify validation rules from CreateVehicleModelCommandRequestValidator and UpdateVehicleModelCommandRequestValidator
- Understand command behavior from CreateVehicleModelCommand and UpdateVehicleModelCommand persistence layer
- Determine specific edge cases that maximize coverage beyond existing tests
- Verify test independence and determinism requirements
- Plan verification strategy for both Result state and database side effects
- Ensure no production code modifications unless absolutely necessary

## Overview

Add at least 3 new integration tests to VehicleModelCommandsIntegrationTests.cs that validate edge case behavior for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Tests will focus on scenarios involving non-existing foreign key references, validation failures, and relationship updates, verifying both command Result state and actual database persistence (or lack thereof on failure).

## Assumptions and Rules from CLAUDE.md

### Assumptions
- The validator's global name uniqueness check is the intended behavior (not brand-specific uniqueness)
- Seeded test database contains sufficient VehicleBrand, VehicleType, and various type entities for realistic testing
- Existing test pattern with helper methods (InstantiateValidCreateRequest, GetUpdatedModel, etc.) should be extended
- Unique test data should use Guid.NewGuid() in names to ensure determinism

### Rules from lanos-test skill
- **Inheritance**: Use `IntegrationTestBase` with primary constructor injection
- **No mocks**: Use real `Context` (DbContext) for all data access
- **MediatR**: Send all commands through `Sender` (never invoke handlers directly)
- **Dual verification**: Assert both `Result` state (IsSuccess, Error, Value) and database side effects via Context queries
- **Failure verification**: For failed commands, verify no partial data was persisted to the database
- **Determinism**: Use unique names with `Guid.NewGuid()` to avoid cross-test contamination
- **Naming convention**: `Method_Scenario_Should_ExpectedOutcome` or `Method_Scenario_ShouldNot_ExpectedOutcome`
- **Relationships**: Use `.Include()` when verifying many-to-many navigation properties
- **No production changes**: Only modify tests unless a real defect blocks test implementation

### No ambiguous or missing rules

All necessary patterns, infrastructure, and conventions are clearly established in the existing test file and lanos-test skill documentation.

## Step-by-Step Implementation

1. **Read and analyze existing tests thoroughly**
- Dependencies: VehicleModelCommandsIntegrationTests.cs
- Tools: Read
- Confirm current test coverage and identify gaps

2. **Add test: Create with non-existing BrandId**
- Dependencies: Understanding of CreateVehicleModelCommandRequestValidator
- Tools: Edit
- Create command with `Guid.NewGuid()` for BrandId (guaranteed non-existing)
- Assert: Result.IsSuccess = false, Result.Error is not null
- Verify: No VehicleModel persisted in Context with the attempted name

3. **Add test: Create with non-existing TypeId**
- Dependencies: Step 2 pattern
- Tools: Edit
- Create command with `Guid.NewGuid()` for TypeId
- Assert: Result failure and no database persistence

4. **Add test: Create with non-existing type relationship IDs**
- Dependencies: Real type entities from Context
- Tools: Edit
- Fetch real BrandId and TypeId, use `Guid.NewGuid()` for one or more type collections (Engine/Transmission/Body/Drivetrain)
- Assert: Validation fails, no VehicleModel created

5. **Add test: Create with duplicate name**
- Dependencies: Existing VehicleModel in test database
- Tools: Edit
- Query existing model name from Context
- Attempt to create new model with same name but different brand
- Assert: Validation fails with AlreadyExistingNameValue message

6. **Add test: Update with non-existing model ID**
- Dependencies: UpdateVehicleModelCommandRequestValidator
- Tools: Edit
- Create UpdateVehicleModelCommandRequest with `Guid.Empty`
- Assert: Result.IsSuccess = false, handler returns KeyNotFoundException-based error

7. **Add test: Update with non-existing type IDs**
- Dependencies: Existing VehicleModel for update
- Tools: Edit
- Fetch real model, create update request with some non-existing type IDs
- Assert: Validation fails, original model relationships unchanged in database

8. **Verify test independence and determinism**
- Dependencies: All new tests written
- Tools: Bash (dotnet test)
- Run tests multiple times in different orders
- Confirm each test passes independently

9. **Build and run integration tests**
- Dependencies: All edits complete
- Tools: Bash
- Commands: `dotnet build tests/IntegrationTests` and `dotnet test tests/IntegrationTests --filter "FullyQualifiedName~VehicleModelCommands"`
- Confirm all tests pass with expected coverage

## Error Handling and Uncertainties

**Potential Issues:**
- Test database may not have sufficient variety of seeded type entities (mitigate by checking Context.Set().Count() first)
- Unique name generation could theoretically collide (extremely unlikely with Guid-based names)
- Validation vs persistence failures may have different error types (verify by examining actual Result.Error content)

**Mitigation:**
- Use existing helper method patterns (InstantiateValidCreateRequest demonstrates safe data fetching)
- Follow established test pattern of querying Context for real entities before test execution
- If insufficient test data exists, note in output but tests should still validate the command/validator behavior

**No major uncertainties** - task requirements, codebase structure, and implementation patterns are all well-defined.