### PR TITLE
2249 test merged staging validation

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,175 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModel_IfBrandIdDoesNotExist()
+    {
+        // Arrange
+        const string testModelName = "test-nonexisting-brand";
+        var nonExistingBrandId = Guid.NewGuid();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+
+        var availableEngineTypes = new[]
+        {
+            await Context.Set<VehicleEngineType>().OrderBy(x => x.Name).FirstAsync()
+        };
+        var availableTransmissionTypes = new[]
+        {
+            await Context.Set<VehicleTransmissionType>().OrderBy(x => x.Name).FirstAsync()
+        };
+        var availableDrivetrainTypes = new[]
+        {
+            await Context.Set<VehicleDrivetrainType>().OrderBy(x => x.Name).FirstAsync()
+        };
+        var availableBodyTypes = new[]
+        {
+            await Context.Set<VehicleBodyType>().OrderBy(x => x.Name).FirstAsync()
+        };
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            testModelName,
+            nonExistingBrandId,
+            type.Id,
+            2005,
+            2010,
+            availableEngineTypes.Select(x => x.Id),
+            availableTransmissionTypes.Select(x => x.Id),
+            availableDrivetrainTypes.Select(x => x.Id),
+            availableBodyTypes.Select(x => x.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var createdModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name.Equals(testModelName));
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        createdModel
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModel_IfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        const string testModelName = "test-nonexisting-enginetype";
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        var availableTransmissionTypes = new[]
+        {
+            await Context.Set<VehicleTransmissionType>().OrderBy(x => x.Name).FirstAsync()
+        };
+        var availableDrivetrainTypes = new[]
+        {
+            await Context.Set<VehicleDrivetrainType>().OrderBy(x => x.Name).FirstAsync()
+        };
+        var availableBodyTypes = new[]
+        {
+            await Context.Set<VehicleBodyType>().OrderBy(x => x.Name).FirstAsync()
+        };
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            testModelName,
+            brand.Id,
+            type.Id,
+            2005,
+            2010,
+            new[] { nonExistingEngineTypeId },
+            availableTransmissionTypes.Select(x => x.Id),
+            availableDrivetrainTypes.Select(x => x.Id),
+            availableBodyTypes.Select(x => x.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var createdModel = await Context.Set<VehicleModel>()
+            .FirstOrDefaultAsync(m => m.Name.Equals(testModelName));
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        createdModel
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModel_IfNameAlreadyExists()
+    {
+        // Arrange
+        const string duplicateModelName = "test-duplicate-name";
+
+        // First, create a valid model
+        var firstCommandRequest = await InstantiateValidCreateRequestWithCustomName(duplicateModelName);
+        var firstResponse = await Sender.Send(firstCommandRequest);
+        firstResponse.IsSuccess.Should().BeTrue();
+
+        // Now try to create another model with the same name
+        var secondCommandRequest = await InstantiateValidCreateRequestWithCustomName(duplicateModelName);
+
+        // Act
+        var response = await Sender.Send(secondCommandRequest);
+        var modelsWithSameName = await Context.Set<VehicleModel>()
+            .Where(m => m.Name.Equals(duplicateModelName))
+            .ToListAsync();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        modelsWithSameName
+            .Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModel_IfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var updatedModel = await GetUpdatedModel();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+
+        // Store original engine types for comparison
+        var originalEngineTypeIds = updatedModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            updatedModel.Id,
+            updatedModel.MaximumProductionYear,
+            originalEngineTypeIds.Append(nonExistingEngineTypeId),
+            updatedModel.AvailableTransmissionTypes.Select(t => t.Id),
+            updatedModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            updatedModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Reload model to verify relationships unchanged
+        var reloadedModel = await GetUpdatedModel();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        reloadedModel.AvailableEngineTypes
+            .Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(
@@ -163,6 +326,11 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
     private async Task<CreateVehicleModelCommandRequest> InstantiateValidCreateRequest()
     {
+        return await InstantiateValidCreateRequestWithCustomName(ModelName);
+    }
+
+    private async Task<CreateVehicleModelCommandRequest> InstantiateValidCreateRequestWithCustomName(string modelName)
+    {
         var brand = await Context.Set<VehicleBrand>().FirstAsync();
         var type = await Context.Set<VehicleType>().FirstAsync();
         const int minimalProductionYear = 2005;
@@ -194,7 +362,7 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
 
         return new CreateVehicleModelCommandRequest(
-            ModelName,
+            modelName,
             brand.Id,
             type.Id,
             minimalProductionYear,


### PR DESCRIPTION
Implementation of 2249

Add meaningful integration test coverage for VehicleModel command behavior.
Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.
Requirements:
Do not introduce mocks or an in-memory database.

Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.

Add at least 3 new integration tests.

Cover realistic domain/application edge cases, not only empty Guid validation.

Verify both Result state and persisted database state where relevant.

Prefer reusing seeded reference data from the real test database.

Keep the tests deterministic and independent from execution order.

Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.

Preserve the project’s current naming/style conventions.

Suggested cases to consider:
creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;

creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;

updating a model with non-existing related type IDs should fail without partially changing existing relationships;

updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.

After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist
- Review existing test patterns in VehicleModelCommandsIntegrationTests.cs
- Understand validation rules from validators and command execution logic
- Identify edge cases not covered by existing 4 tests
- Design test cases verifying both Result state and database persistence
- Ensure tests are deterministic and use seeded reference data

## Overview
Add at least 3 new integration tests to VehicleModelCommandsIntegrationTests.cs covering VehicleModel command edge cases: (1) Create with non-existing foreign key IDs (Brand, Type, EngineType, etc.) should fail without persisting, (2) Create with duplicate name should fail per global uniqueness constraint, (3) Update with non-existing type IDs should fail without changing relationships.

## Assumptions and Rules
- No CLAUDE.md found; following existing test patterns
- xUnit [Fact] attribute, Arrange-Act-Assert pattern, FluentAssertions
- Method naming: `Send_{Command}Request_Should{Not}_{ExpectedBehavior}_If{Condition}`
- Verify both Result.IsSuccess/Error and database state (Context.FindAsync)
- Reuse seeded data via Context.Set().FirstAsync()
- Name uniqueness is global (not per-brand) based on validator
- Failed creates/updates return Result.Failure or throw (caught by validation pipeline)

## Step-by-Step Implementation
1. Add test: Create with non-existing BrandId → Result.IsSuccess=false, no VehicleModel persisted
2. Add test: Create with non-existing EngineType ID → Result.IsSuccess=false, no VehicleModel persisted
3. Add test: Create with duplicate name → Result.IsSuccess=false per global uniqueness
4. Add test: Update with non-existing type IDs → Result.IsSuccess=false, relationships unchanged in DB
5. Add helper methods if needed to reduce duplication

## Error Handling and Uncertainties
- Task mentions "duplicate name for same brand" but validator enforces global uniqueness; will test actual behavior
- Will test at least one type collection thoroughly (EngineType) as representative; can add others for comprehensive coverage
- All tests verify both Result and DB state, making any misunderstanding evident
- If defects found, document clearly and only fix if necessary per task requirements