### PR TITLE
SCRUM-355 45y

### DIFF
--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -102,12 +102,232 @@ public sealed class VehicleModelCommandsIntegrationTests(
 
         // Act
         var response = await Sender.Send(commandRequest);
-        
+
         // Assert
         response.Error
             .Should().NotBeNull();
         response.IsSuccess
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfBrandIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingBrandId = Guid.NewGuid();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        const int minimalProductionYear = 2005;
+        const int maximumProductionYear = 2010;
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingBrandModel",
+            nonExistingBrandId,
+            type.Id,
+            minimalProductionYear,
+            maximumProductionYear,
+            [], [], [], []
+        );
+
+        var initialModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var finalModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        finalModelCount
+            .Should().Be(initialModelCount);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var nonExistingTypeId = Guid.NewGuid();
+        const int minimalProductionYear = 2005;
+        const int maximumProductionYear = 2010;
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "NonExistingTypeModel",
+            brand.Id,
+            nonExistingTypeId,
+            minimalProductionYear,
+            maximumProductionYear,
+            [], [], [], []
+        );
+
+        var initialModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var finalModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        finalModelCount
+            .Should().Be(initialModelCount);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var brand = await Context.Set<VehicleBrand>().FirstAsync();
+        var type = await Context.Set<VehicleType>().FirstAsync();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+        const int minimalProductionYear = 2005;
+        const int maximumProductionYear = 2010;
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            "InvalidEngineTypeModel",
+            brand.Id,
+            type.Id,
+            minimalProductionYear,
+            maximumProductionYear,
+            [nonExistingEngineTypeId],
+            [], [], []
+        );
+
+        var initialModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var finalModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        finalModelCount
+            .Should().Be(initialModelCount);
+    }
+
+    [Fact]
+    public async Task Send_CreateRequest_ShouldNot_AddNewModelIfDuplicateNameForSameBrand()
+    {
+        // Arrange
+        var existingModel = await Context.Set<VehicleModel>()
+            .Include(m => m.VehicleBrand)
+            .Include(m => m.VehicleType)
+            .FirstAsync();
+
+        var validEngineType = await Context.Set<VehicleEngineType>().FirstAsync();
+        const int minimalProductionYear = 2005;
+        const int maximumProductionYear = 2010;
+
+        var commandRequest = new CreateVehicleModelCommandRequest(
+            existingModel.Name,
+            existingModel.VehicleBrandId,
+            existingModel.VehicleTypeId,
+            minimalProductionYear,
+            maximumProductionYear,
+            [validEngineType.Id],
+            [], [], []
+        );
+
+        var initialModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var finalModelCount = await Context.Set<VehicleModel>().CountAsync();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        finalModelCount
+            .Should().Be(initialModelCount);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfModelIdDoesNotExist()
+    {
+        // Arrange
+        var nonExistingModelId = Guid.NewGuid();
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            nonExistingModelId,
+            2025,
+            [], [], [], []
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfEngineTypeIdDoesNotExist()
+    {
+        // Arrange
+        var existingModel = await GetUpdatedModel();
+        var nonExistingEngineTypeId = Guid.NewGuid();
+        var originalEngineTypeIds = existingModel.AvailableEngineTypes.Select(t => t.Id).ToList();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            existingModel.MaximumProductionYear,
+            [nonExistingEngineTypeId],
+            existingModel.AvailableTransmissionTypes.Select(t => t.Id),
+            existingModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            existingModel.AvailableBodyTypes.Select(t => t.Id)
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var unchangedModel = await GetUpdatedModel();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        unchangedModel.AvailableEngineTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalEngineTypeIds);
+    }
+
+    [Fact]
+    public async Task Send_UpdateRequest_ShouldNot_UpdateModelIfBodyTypeIdDoesNotExist()
+    {
+        // Arrange
+        var existingModel = await GetUpdatedModel();
+        var nonExistingBodyTypeId = Guid.NewGuid();
+        var originalBodyTypeIds = existingModel.AvailableBodyTypes.Select(t => t.Id).ToList();
+
+        var commandRequest = new UpdateVehicleModelCommandRequest(
+            existingModel.Id,
+            existingModel.MaximumProductionYear,
+            existingModel.AvailableEngineTypes.Select(t => t.Id),
+            existingModel.AvailableTransmissionTypes.Select(t => t.Id),
+            existingModel.AvailableDrivetrainTypes.Select(t => t.Id),
+            [nonExistingBodyTypeId]
+        );
+
+        // Act
+        var response = await Sender.Send(commandRequest);
+        var unchangedModel = await GetUpdatedModel();
+
+        // Assert
+        response.Error
+            .Should().NotBe(Error.None);
+        response.IsSuccess
+            .Should().BeFalse();
+        unchangedModel.AvailableBodyTypes.Select(t => t.Id)
+            .Should().BeEquivalentTo(originalBodyTypeIds);
     }
 
     private UpdateVehicleModelCommandRequest GetValidUpdateRequest(

--- a/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
+++ b/tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs
@@ -12,6 +12,8 @@ public sealed class VehicleModelCommandsIntegrationTests(
     IntegrationTestsWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     private const string ModelName = "test";
+    private const int MinimalProductionYear = 2005;
+    private const int MaximumProductionYear = 2010;
     
     [Fact]
     public async Task Send_CreateRequest_Should_AddNewModelIfRequestIsValid()
@@ -116,15 +118,13 @@ public sealed class VehicleModelCommandsIntegrationTests(
         // Arrange
         var nonExistingBrandId = Guid.NewGuid();
         var type = await Context.Set<VehicleType>().FirstAsync();
-        const int minimalProductionYear = 2005;
-        const int maximumProductionYear = 2010;
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             "NonExistingBrandModel",
             nonExistingBrandId,
             type.Id,
-            minimalProductionYear,
-            maximumProductionYear,
+            MinimalProductionYear,
+            MaximumProductionYear,
             [], [], [], []
         );
 
@@ -149,15 +149,13 @@ public sealed class VehicleModelCommandsIntegrationTests(
         // Arrange
         var brand = await Context.Set<VehicleBrand>().FirstAsync();
         var nonExistingTypeId = Guid.NewGuid();
-        const int minimalProductionYear = 2005;
-        const int maximumProductionYear = 2010;
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             "NonExistingTypeModel",
             brand.Id,
             nonExistingTypeId,
-            minimalProductionYear,
-            maximumProductionYear,
+            MinimalProductionYear,
+            MaximumProductionYear,
             [], [], [], []
         );
 
@@ -183,15 +181,13 @@ public sealed class VehicleModelCommandsIntegrationTests(
         var brand = await Context.Set<VehicleBrand>().FirstAsync();
         var type = await Context.Set<VehicleType>().FirstAsync();
         var nonExistingEngineTypeId = Guid.NewGuid();
-        const int minimalProductionYear = 2005;
-        const int maximumProductionYear = 2010;
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             "InvalidEngineTypeModel",
             brand.Id,
             type.Id,
-            minimalProductionYear,
-            maximumProductionYear,
+            MinimalProductionYear,
+            MaximumProductionYear,
             [nonExistingEngineTypeId],
             [], [], []
         );
@@ -221,15 +217,13 @@ public sealed class VehicleModelCommandsIntegrationTests(
             .FirstAsync();
 
         var validEngineType = await Context.Set<VehicleEngineType>().FirstAsync();
-        const int minimalProductionYear = 2005;
-        const int maximumProductionYear = 2010;
 
         var commandRequest = new CreateVehicleModelCommandRequest(
             existingModel.Name,
             existingModel.VehicleBrandId,
             existingModel.VehicleTypeId,
-            minimalProductionYear,
-            maximumProductionYear,
+            MinimalProductionYear,
+            MaximumProductionYear,
             [validEngineType.Id],
             [], [], []
         );
@@ -385,8 +379,6 @@ public sealed class VehicleModelCommandsIntegrationTests(
     {
         var brand = await Context.Set<VehicleBrand>().FirstAsync();
         var type = await Context.Set<VehicleType>().FirstAsync();
-        const int minimalProductionYear = 2005;
-        const int maximumProductionYear = 2010;
 
         IEnumerable<VehicleEngineType> availableEngineTypes =
         [
@@ -417,8 +409,8 @@ public sealed class VehicleModelCommandsIntegrationTests(
             ModelName,
             brand.Id,
             type.Id,
-            minimalProductionYear,
-            maximumProductionYear,
+            MinimalProductionYear,
+            MaximumProductionYear,
             availableEngineTypes.Select(x => x.Id),
             availableTransmissionTypes.Select(x => x.Id),
             availableDrivetrainTypes.Select(x => x.Id),


### PR DESCRIPTION
Implementation of SCRUM-355

Add meaningful integration test coverage for VehicleModel command behavior.
Focus on tests that validate edge cases around CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest using the existing integration testing infrastructure. Follow the style already used in tests/IntegrationTests/VehicleModels/VehicleModelCommandsIntegrationTests.cs.
Requirements:
Do not introduce mocks or an in-memory database.
Use the existing IntegrationTestBase, IntegrationTestsWebApplicationFactory, MediatR Sender, EF Core Context, xUnit, and FluentAssertions patterns.
Add at least 3 new integration tests.
Cover realistic domain/application edge cases, not only empty Guid validation.
Verify both Result state and persisted database state where relevant.
Prefer reusing seeded reference data from the real test database.
Keep the tests deterministic and independent from execution order.
Do not modify production code unless a real defect is discovered and the fix is necessary for the tests to pass.
Preserve the project’s current naming/style conventions.
Suggested cases to consider:
creating a vehicle model with non-existing brand/type IDs should fail and should not persist a new VehicleModel;
creating a duplicate vehicle model name for the same brand should fail or be handled consistently with the existing domain rules;
updating a model with non-existing related type IDs should fail without partially changing existing relationships;
updating available engine/transmission/body/drivetrain types should replace or preserve relationships according to the existing handler behavior.
After implementation, briefly explain what tests were added and why they improve coverage.

# Implementation Plan

## Conceptual Checklist

- Analyze existing test structure and helper method patterns
- Identify seeded reference data available for test scenarios
- Map suggested test cases to validator/handler behavior
- Design test data that ensures deterministic, independent execution
- Verify both Result failures and database non-persistence for negative cases
- Follow existing naming conventions and assertion patterns
- Prioritize edge cases beyond simple empty Guid validation

## Overview

Add at least 3 integration tests to `VehicleModelCommandsIntegrationTests.cs` covering realistic edge cases for CreateVehicleModelCommandRequest and UpdateVehicleModelCommandRequest. Tests will validate domain rules around foreign key constraints, unique constraints, and relationship updates using the real test database with seeded data.

## Assumptions and Rules

From task requirements:
- No mocks or in-memory database
- Use existing IntegrationTestBase, MediatR Sender, EF Core Context, xUnit, FluentAssertions
- Verify both Result state and persisted database state
- Reuse seeded reference data from real test database
- Keep tests deterministic and order-independent
- Only modify production code if real defect discovered
- Preserve project naming/style conventions

From codebase analysis:
- VehicleModel has unique constraint on (Name, VehicleBrandId)
- Validators check existence of Brand/Type/AspectType IDs before persistence
- UpdateVehicleModelCommand replaces aspect collections entirely
- SaveChanges occurs after command execution, enabling rollback on validation failure

## Step-by-Step Implementation

1. **Add test for creating vehicle model with non-existing BrandId**
- Tools: Read existing test structure, Context (for verification), Sender
- Create request with Guid.NewGuid() as BrandId (guaranteed not to exist)
- Assert Result.IsSuccess = false, verify no VehicleModel persisted to database

2. **Add test for creating duplicate model name for same brand**
- Dependencies: Query database for existing brand and model from seeded data
- Create request with same Name + BrandId as existing model
- Assert validation failure due to unique constraint violation
- Verify database count unchanged

3. **Add test for creating model with non-existing EngineType/BodyType IDs**
- Use mix of valid + invalid aspect type IDs (Guid.NewGuid())
- Assert Result failure, verify no partial persistence

4. **Add test for updating model with non-existing aspect type IDs**
- Dependencies: Fetch existing model with GetUpdatedModel() pattern
- Include non-existing aspect type ID in update collection
- Assert failure, verify original aspect collections unchanged

5. **Add test for updating model with non-existing model ID**
- Create UpdateVehicleModelCommandRequest with Guid.NewGuid() as Id
- Assert Result failure with NotFound error

6. **Verify test isolation and determinism**
- Review helper methods for proper data cleanup/isolation
- Ensure tests don't depend on execution order
- Run tests multiple times to confirm stability

## Error Handling and Uncertainties

Potential issues:
- **Race conditions**: Use unique model names per test to avoid conflicts
- **Database state pollution**: Verify IntegrationTestBase properly isolates test scopes
- **Seeded data assumptions**: Confirm seeded brands/types exist before test execution
- **Validator vs DB constraint timing**: Some cases may fail at validation layer vs persistence layer - document which layer catches each edge case in test names

Mitigation: Follow existing test patterns closely, use helper methods for data retrieval, ensure unique test data, verify database state explicitly rather than assuming rollback behavior.