### PR TITLE
SCRUM-447 test repro error fix

### DIFF
--- a/src/LanosCertifiedStore.Application/Vehicles/IVehicleFilteringRequestParameters.cs
+++ b/src/LanosCertifiedStore.Application/Vehicles/IVehicleFilteringRequestParameters.cs
@@ -5,10 +5,17 @@ namespace LanosCertifiedStore.Application.Vehicles;
 
 public interface IVehicleFilteringRequestParameters : IFilteringRequestParameters<Vehicle>
 {
-    string? Brand { get; set; }
-    string? Model { get; set; }
-    string? Type { get; set; }
-    string? Color { get; set; }
+    List<Guid>? BrandIds { get; set; }
+    List<Guid>? ModelIds { get; set; }
+    List<Guid>? VehicleTypeIds { get; set; }
+    List<Guid>? ColorIds { get; set; }
+    List<Guid>? BodyTypeIds { get; set; }
+    List<Guid>? EngineTypeIds { get; set; }
+    List<Guid>? TransmissionTypeIds { get; set; }
+    List<Guid>? DrivetrainTypeIds { get; set; }
+    List<Guid>? LocationTownIds { get; set; }
+    List<Guid>? LocationAreaIds { get; set; }
+    List<Guid>? LocationRegionIds { get; set; }
     decimal? LowerPriceLimit { get; set; }
     decimal? UpperPriceLimit { get; set; }
 }

--- a/src/LanosCertifiedStore.Application/Vehicles/IVehicleService.cs
+++ b/src/LanosCertifiedStore.Application/Vehicles/IVehicleService.cs
@@ -1,0 +1,22 @@
+using LanosCertifiedStore.Application.Shared.DtosRelated;
+using LanosCertifiedStore.Application.Vehicles.Dtos;
+using LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
+using LanosCertifiedStore.Application.Vehicles.Queries.VehicleDetailsQueryRelated;
+using LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
+
+namespace LanosCertifiedStore.Application.Vehicles;
+
+public interface IVehicleService
+{
+    Task<IEnumerable<VehicleDto>> GetVehicleCollection(
+        VehiclesQueryRequest queryRequest,
+        CancellationToken cancellationToken);
+
+    Task<VehicleDto> GetSingleVehicle(
+        VehicleSingleQueryRequest queryRequest,
+        CancellationToken cancellationToken);
+
+    Task<ItemsCountDto> GetVehiclesCount(
+        CountVehiclesQueryRequest queryRequest,
+        CancellationToken cancellationToken);
+}

--- a/src/LanosCertifiedStore.Application/Vehicles/Queries/CountVehiclesQueryRelated/CountVehiclesQueryHandler.cs
+++ b/src/LanosCertifiedStore.Application/Vehicles/Queries/CountVehiclesQueryRelated/CountVehiclesQueryHandler.cs
@@ -1,11 +1,13 @@
-﻿namespace LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
+﻿using LanosCertifiedStore.Application.Shared.DtosRelated;
+using LanosCertifiedStore.Application.Shared.ResultRelated;
+using MediatR;
 
-// TODO
-// internal sealed class CountVehiclesQueryHandler(IUnitOfWork unitOfWork) : 
-//     CountItemsQueryRequestHandlerBase<Vehicle>(unitOfWork),
-//     IRequestHandler<CountVehiclesQueryRequest, Result<ItemsCountDto>>
-// {
-//     public Task<Result<ItemsCountDto>> Handle(
-//         CountVehiclesQueryRequest request, CancellationToken cancellationToken) =>
-//         base.Handle(request, cancellationToken);
-// }
+namespace LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
+
+internal sealed class CountVehiclesQueryHandler(IVehicleService vehicleService) :
+    IRequestHandler<CountVehiclesQueryRequest, Result<ItemsCountDto>>
+{
+    public Task<Result<ItemsCountDto>> Handle(
+        CountVehiclesQueryRequest request, CancellationToken cancellationToken) =>
+        vehicleService.GetVehiclesCount(request, cancellationToken);
+}

--- a/src/LanosCertifiedStore.Application/Vehicles/Queries/CountVehiclesQueryRelated/CountVehiclesQueryRequest.cs
+++ b/src/LanosCertifiedStore.Application/Vehicles/Queries/CountVehiclesQueryRelated/CountVehiclesQueryRequest.cs
@@ -1,4 +1,11 @@
-﻿namespace LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
+﻿using LanosCertifiedStore.Application.Shared.DtosRelated;
+using LanosCertifiedStore.Application.Shared.RequestRelated.QueryRelated;
+using LanosCertifiedStore.Application.Shared.ResultRelated;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using MediatR;
 
-// public sealed record CountVehiclesQueryRequest(IFilteringRequestParameters<Vehicle> RequestParameters) : 
-//     CountItemsQueryRequestBase<Vehicle>(RequestParameters), IRequest<Result<ItemsCountDto>>;
+namespace LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
+
+public sealed record CountVehiclesQueryRequest(
+    IVehicleFilteringRequestParameters FilteringParameters) :
+    ICountQueryRequest<Vehicle>, IRequest<Result<ItemsCountDto>>;

--- a/src/LanosCertifiedStore.Application/Vehicles/Queries/VehiclesQueryRelated/VehiclesQueryHandler.cs
+++ b/src/LanosCertifiedStore.Application/Vehicles/Queries/VehiclesQueryRelated/VehiclesQueryHandler.cs
@@ -1,11 +1,15 @@
-﻿namespace LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
+﻿using LanosCertifiedStore.Application.Shared.ResultRelated;
+using LanosCertifiedStore.Application.Vehicles.Dtos;
+using MediatR;
 
-// TODO
-// internal sealed class VehiclesQueryHandler(IUnitOfWork unitOfWork, IMapper mapper) :
-//     CollectionQueryHandlerBase<Vehicle, VehicleFilteringRequestParameters, VehicleDto>(unitOfWork, mapper),
-//     IRequestHandler<VehiclesQueryRequest, Result<PaginationResult<VehicleDto>>>
-// {
-//     public Task<Result<PaginationResult<VehicleDto>>> Handle(VehiclesQueryRequest request,
-//         CancellationToken cancellationToken) =>
-//         base.Handle(request, cancellationToken);
-// }
+namespace LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
+
+internal sealed class VehiclesQueryHandler(IVehicleService vehicleService) :
+    IRequestHandler<VehiclesQueryRequest, Result<PaginationResult<VehicleDto>>>
+{
+    public async Task<Result<PaginationResult<VehicleDto>>> Handle(
+        VehiclesQueryRequest request, CancellationToken cancellationToken) =>
+        new PaginationResult<VehicleDto>(
+            await vehicleService.GetVehicleCollection(request, cancellationToken),
+            request.FilteringParameters.PageIndex);
+}

--- a/src/LanosCertifiedStore.Application/Vehicles/Queries/VehiclesQueryRelated/VehiclesQueryRequest.cs
+++ b/src/LanosCertifiedStore.Application/Vehicles/Queries/VehiclesQueryRelated/VehiclesQueryRequest.cs
@@ -1,5 +1,10 @@
-﻿namespace LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
+﻿using LanosCertifiedStore.Application.Shared.RequestRelated.QueryRelated;
+using LanosCertifiedStore.Application.Shared.ResultRelated;
+using LanosCertifiedStore.Application.Vehicles.Dtos;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
 
-// public sealed record VehiclesQueryRequest(
-//     IVehicleFilteringRequestParameters RequestParameters, bool IsTracked) : 
-//     CollectionQueryRequestBase<Vehicle, PaginationResult<VehicleDto>>(RequestParameters, IsTracked);
+namespace LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
+
+public sealed record VehiclesQueryRequest(
+    IVehicleFilteringRequestParameters FilteringParameters) :
+    ICollectionQueryRequest<Vehicle, PaginationResult<VehicleDto>, VehicleDto>;

--- a/src/LanosCertifiedStore.Application/Vehicles/VehicleFilteringRequestParameters.cs
+++ b/src/LanosCertifiedStore.Application/Vehicles/VehicleFilteringRequestParameters.cs
@@ -6,10 +6,17 @@ namespace LanosCertifiedStore.Application.Vehicles;
 public sealed class VehicleFilteringRequestParameters : BaseFilteringRequestParameters<Vehicle>,
     IVehicleFilteringRequestParameters
 {
-    public string? Brand { get; set; }
-    public string? Model { get; set; }
-    public string? Type { get; set; }
-    public string? Color { get; set; }
+    public List<Guid>? BrandIds { get; set; }
+    public List<Guid>? ModelIds { get; set; }
+    public List<Guid>? VehicleTypeIds { get; set; }
+    public List<Guid>? ColorIds { get; set; }
+    public List<Guid>? BodyTypeIds { get; set; }
+    public List<Guid>? EngineTypeIds { get; set; }
+    public List<Guid>? TransmissionTypeIds { get; set; }
+    public List<Guid>? DrivetrainTypeIds { get; set; }
+    public List<Guid>? LocationTownIds { get; set; }
+    public List<Guid>? LocationAreaIds { get; set; }
+    public List<Guid>? LocationRegionIds { get; set; }
     public decimal? LowerPriceLimit { get; set; }
     public decimal? UpperPriceLimit { get; set; }
 }

--- a/src/LanosCertifiedStore.Infrastructure/DependencyInjection.cs
+++ b/src/LanosCertifiedStore.Infrastructure/DependencyInjection.cs
@@ -11,6 +11,7 @@ using LanosCertifiedStore.Application.VehicleEngineTypes;
 using LanosCertifiedStore.Application.VehicleModels;
 using LanosCertifiedStore.Application.VehicleTransmissionTypes;
 using LanosCertifiedStore.Application.VehicleTypes;
+using LanosCertifiedStore.Application.Vehicles;
 using LanosCertifiedStore.Infrastructure.Authentication;
 using LanosCertifiedStore.Infrastructure.Authentication.KeyCloak;
 using LanosCertifiedStore.Infrastructure.Authorization;
@@ -87,6 +88,7 @@ public static class DependencyInjection
         services.AddScoped<IVehicleBrandService, VehicleBrandService>();
         services.AddScoped<IVehicleColorService, VehicleColorService>();
         services.AddScoped<IVehicleModelService, VehicleModelService>();
+        services.AddScoped<IVehicleService, VehicleService>();
     }
 
     private static void AddTypeRelatedServices(IServiceCollection services)

--- a/src/LanosCertifiedStore.Infrastructure/Vehicles/VehicleService.cs
+++ b/src/LanosCertifiedStore.Infrastructure/Vehicles/VehicleService.cs
@@ -1,0 +1,36 @@
+using LanosCertifiedStore.Application.Shared.DtosRelated;
+using LanosCertifiedStore.Application.Vehicles;
+using LanosCertifiedStore.Application.Vehicles.Dtos;
+using LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
+using LanosCertifiedStore.Application.Vehicles.Queries.VehicleDetailsQueryRelated;
+using LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
+using LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;
+
+namespace LanosCertifiedStore.Infrastructure.Vehicles;
+
+internal sealed class VehicleService(
+    CollectionVehiclesQuery collectionVehiclesQuery,
+    SingleVehicleQuery singleVehicleQuery,
+    CountVehiclesQuery countVehiclesQuery) : IVehicleService
+{
+    public async Task<IEnumerable<VehicleDto>> GetVehicleCollection(
+        VehiclesQueryRequest queryRequest,
+        CancellationToken cancellationToken)
+    {
+        return await collectionVehiclesQuery.Execute(queryRequest, cancellationToken);
+    }
+
+    public async Task<VehicleDto> GetSingleVehicle(
+        VehicleSingleQueryRequest queryRequest,
+        CancellationToken cancellationToken)
+    {
+        return await singleVehicleQuery.Execute(queryRequest, cancellationToken);
+    }
+
+    public async Task<ItemsCountDto> GetVehiclesCount(
+        CountVehiclesQueryRequest queryRequest,
+        CancellationToken cancellationToken)
+    {
+        return await countVehiclesQuery.Execute(queryRequest, cancellationToken);
+    }
+}

--- a/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/CollectionVehiclesQuery.cs
+++ b/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/CollectionVehiclesQuery.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using LanosCertifiedStore.Application.Vehicles.Dtos;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
+using LanosCertifiedStore.Persistence.Queries.Common.Contracts;
+using LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated.Common;
+
+namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;
+
+public sealed class CollectionVehiclesQuery(
+    ApplicationDatabaseContext context,
+    IQueryFilteringCriteriaSelector<Vehicle> filteringCriteriaSelector,
+    IQuerySortingSettingsSelector<Vehicle> sortingSettingsSelector,
+    IQueryPaginator queryPaginator,
+    IMapper mapper) : CollectionVehiclesQueryBase<VehicleDto>(
+    context,
+    filteringCriteriaSelector,
+    sortingSettingsSelector,
+    queryPaginator,
+    mapper);

--- a/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/Common/CollectionVehiclesQueryBase.cs
+++ b/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/Common/CollectionVehiclesQueryBase.cs
@@ -1,0 +1,31 @@
+using AutoMapper;
+using LanosCertifiedStore.Application.Shared.RequestRelated.QueryRelated;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
+using LanosCertifiedStore.Persistence.Queries.Common.Classes.QueryBaseRelated;
+using LanosCertifiedStore.Persistence.Queries.Common.Contracts;
+
+namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated.Common;
+
+public abstract class CollectionVehiclesQueryBase<TDto>(
+    ApplicationDatabaseContext context,
+    IQueryFilteringCriteriaSelector<Vehicle> filteringCriteriaSelector,
+    IQuerySortingSettingsSelector<Vehicle> sortingSettingsSelector,
+    IQueryPaginator queryPaginator,
+    IMapper mapper) : CollectionQueryBase<Vehicle, TDto>(context, mapper)
+    where TDto : class
+{
+    public sealed override async Task<IEnumerable<TDto>> Execute(
+        IQueryRequest<Vehicle> queryRequest, CancellationToken cancellationToken)
+    {
+        var queryable = GetDatabaseQueryable(context);
+
+        queryable = GetFilteredQueryable(queryRequest, queryable, filteringCriteriaSelector);
+        queryable = GetSortedQueryable(queryRequest, queryable, sortingSettingsSelector);
+        queryable = GetPaginatedQueryable(queryRequest, queryable, queryPaginator);
+
+        var executionResult = await GetQueryResult(queryable, mapper, cancellationToken);
+
+        return executionResult;
+    }
+}

--- a/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/CountVehiclesQuery.cs
+++ b/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/CountVehiclesQuery.cs
@@ -1,0 +1,26 @@
+using LanosCertifiedStore.Application.Shared.DtosRelated;
+using LanosCertifiedStore.Application.Shared.RequestRelated.QueryRelated;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
+using LanosCertifiedStore.Persistence.Queries.Common.Classes.QueryBaseRelated;
+using LanosCertifiedStore.Persistence.Queries.Common.Contracts;
+
+namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;
+
+public sealed class CountVehiclesQuery(
+    ApplicationDatabaseContext context,
+    IQueryFilteringCriteriaSelector<Vehicle> filteringCriteriaSelector) : CountQueryBase<Vehicle>(context)
+{
+    public override async Task<ItemsCountDto> Execute(
+        IQueryRequest<Vehicle> queryRequest,
+        CancellationToken cancellationToken)
+    {
+        var queryable = GetDatabaseQueryable(context);
+
+        queryable = GetFilteredQueryable(queryRequest, queryable, filteringCriteriaSelector);
+
+        var count = await GetItemsCount(queryable, cancellationToken);
+
+        return new ItemsCountDto { Count = count };
+    }
+}

--- a/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/SingleVehicleQuery.cs
+++ b/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/SingleVehicleQuery.cs
@@ -1,0 +1,11 @@
+using AutoMapper;
+using LanosCertifiedStore.Application.Vehicles.Dtos;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
+using LanosCertifiedStore.Persistence.Queries.Common.Classes.QueryBaseRelated;
+
+namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;
+
+public sealed class SingleVehicleQuery(
+    ApplicationDatabaseContext context,
+    IMapper mapper) : SingleQueryBase<Vehicle, VehicleDto>(context, mapper);

--- a/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/SelectorRelated/VehiclesFilteringCriteriaSelector.cs
+++ b/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/SelectorRelated/VehiclesFilteringCriteriaSelector.cs
@@ -1,0 +1,77 @@
+using System.Linq.Expressions;
+using LanosCertifiedStore.Application.Shared.RequestParamsRelated;
+using LanosCertifiedStore.Application.Vehicles;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using LanosCertifiedStore.Persistence.Queries.Common.Classes.SelectorBaseRelated;
+
+namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.SelectorRelated;
+
+internal sealed class VehiclesFilteringCriteriaSelector : QueryFilteringCriteriaSelectorBase<Vehicle>
+{
+    private protected override IReadOnlyCollection<(bool IsValid, Expression<Func<Vehicle, bool>> Expression)>
+        GetAspectMappings(IFilteringRequestParameters<Vehicle> filteringRequestParameters)
+    {
+        var parameters = (filteringRequestParameters as IVehicleFilteringRequestParameters)!;
+
+        return
+        [
+            (
+                IsValidFilterList(parameters.BrandIds),
+                vehicle => parameters.BrandIds!.Contains(vehicle.BrandId)
+            ),
+            (
+                IsValidFilterList(parameters.ModelIds),
+                vehicle => parameters.ModelIds!.Contains(vehicle.ModelId)
+            ),
+            (
+                IsValidFilterList(parameters.VehicleTypeIds),
+                vehicle => parameters.VehicleTypeIds!.Contains(vehicle.VehicleTypeId)
+            ),
+            (
+                IsValidFilterList(parameters.ColorIds),
+                vehicle => parameters.ColorIds!.Contains(vehicle.ColorId)
+            ),
+            (
+                IsValidFilterList(parameters.BodyTypeIds),
+                vehicle => parameters.BodyTypeIds!.Contains(vehicle.BodyTypeId)
+            ),
+            (
+                IsValidFilterList(parameters.EngineTypeIds),
+                vehicle => parameters.EngineTypeIds!.Contains(vehicle.EngineTypeId)
+            ),
+            (
+                IsValidFilterList(parameters.TransmissionTypeIds),
+                vehicle => parameters.TransmissionTypeIds!.Contains(vehicle.TransmissionTypeId)
+            ),
+            (
+                IsValidFilterList(parameters.DrivetrainTypeIds),
+                vehicle => parameters.DrivetrainTypeIds!.Contains(vehicle.DrivetrainTypeId)
+            ),
+            (
+                IsValidFilterList(parameters.LocationTownIds),
+                vehicle => parameters.LocationTownIds!.Contains(vehicle.LocationTownId)
+            ),
+            (
+                IsValidFilterList(parameters.LocationAreaIds),
+                vehicle => parameters.LocationAreaIds!.Contains(vehicle.LocationAreaId)
+            ),
+            (
+                IsValidFilterList(parameters.LocationRegionIds),
+                vehicle => parameters.LocationRegionIds!.Contains(vehicle.LocationRegionId)
+            ),
+            (
+                parameters.LowerPriceLimit.HasValue,
+                vehicle => vehicle.Prices.Any(p => p.PriceValue >= parameters.LowerPriceLimit!.Value)
+            ),
+            (
+                parameters.UpperPriceLimit.HasValue,
+                vehicle => vehicle.Prices.Any(p => p.PriceValue <= parameters.UpperPriceLimit!.Value)
+            )
+        ];
+    }
+
+    private bool IsValidFilterList(List<Guid>? filterList)
+    {
+        return filterList is { Count: > 0 };
+    }
+}

--- a/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/SelectorRelated/VehiclesSortingSettingsSelector.cs
+++ b/src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/SelectorRelated/VehiclesSortingSettingsSelector.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+using LanosCertifiedStore.Application.Shared.RequestParamsRelated;
+using LanosCertifiedStore.Domain.Entities.VehicleRelated;
+using LanosCertifiedStore.Persistence.Queries.Common.Contracts;
+
+namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.SelectorRelated;
+
+internal sealed class VehiclesSortingSettingsSelector : IQuerySortingSettingsSelector<Vehicle>
+{
+    public (Expression<Func<Vehicle, object>> SortingSettings, bool IsAscending) GetSortingSettings(
+        IFilteringRequestParameters<Vehicle> filteringRequestParameters)
+    {
+        return (vehicle => vehicle.CreatedAt, false);
+    }
+}

--- a/src/LanosCertifiedStore.Presentation/Controllers/VehicleRelated/VehiclesController.cs
+++ b/src/LanosCertifiedStore.Presentation/Controllers/VehicleRelated/VehiclesController.cs
@@ -1,95 +1,115 @@
-﻿namespace LanosCertifiedStore.Presentation.Controllers.VehicleRelated;
+﻿using LanosCertifiedStore.Application.Shared.DtosRelated;
+using LanosCertifiedStore.Application.Shared.ResultRelated;
+using LanosCertifiedStore.Application.Vehicles;
+using LanosCertifiedStore.Application.Vehicles.Commands.AddImageToVehicleRelated;
+using LanosCertifiedStore.Application.Vehicles.Commands.CreateVehicleRelated;
+using LanosCertifiedStore.Application.Vehicles.Commands.DeleteVehicleRelated;
+using LanosCertifiedStore.Application.Vehicles.Commands.RemoveImageFromVehicleRelated;
+using LanosCertifiedStore.Application.Vehicles.Commands.SetVehicleMainImageRelated;
+using LanosCertifiedStore.Application.Vehicles.Commands.UpdateVehicleRelated;
+using LanosCertifiedStore.Application.Vehicles.Dtos;
+using LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
+using LanosCertifiedStore.Application.Vehicles.Queries.VehicleDetailsQueryRelated;
+using LanosCertifiedStore.Application.Vehicles.Queries.VehiclePriceRangeQueryRelated;
+using LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
+using LanosCertifiedStore.Presentation.Controllers.Common;
+using LanosCertifiedStore.Presentation.Contracts;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
-// public sealed class VehiclesController : BaseModelRelatedApiController
-// {
-//     [HttpGet]
-//     [ProducesResponseType(typeof(PaginationResult<VehicleDto>), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     public async Task<ActionResult<PaginationResult<VehicleDto>>> GetVehicles(
-//         [FromQuery] VehicleFilteringRequestParameters requestParameters)
-//     {
-//         return HandleResult(await Mediator.Send(new VehiclesQuery(requestParameters)));
-//     }
-//
-//     [HttpGet("{id:guid}")]
-//     [ProducesResponseType(typeof(VehicleDto), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     public async Task<ActionResult<VehicleDto>> GetVehicle(Guid id)
-//     {
-//         return HandleResult(await Mediator.Send(new VehicleSingleQueryRequest(id)));
-//     }
-//     
-//     [HttpGet("countItems")]
-//     [ProducesResponseType(typeof(ItemsCountDto), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-//     public async Task<ActionResult<ItemsCountDto>> GetItemsCount(
-//         [FromQuery] VehicleFilteringRequestParameters requestParameters)
-//     {
-//         return HandleResult(await Mediator.Send(new CountVehiclesQueryRequest(requestParameters)));
-//     }
-//     
-//     [HttpGet("getPriceRange")]
-//     [ProducesResponseType(typeof(Dictionary<string, decimal>), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-//     public async Task<ActionResult<Dictionary<string, decimal>>> GetPriceRange(
-//         [FromQuery] VehicleFilteringRequestParameters requestParameters)
-//     {
-//         return HandleResult(await Mediator.Send(new VehiclePriceRangeQuery(requestParameters)));
-//     }
-//
-//     [HttpPost]
-//     [ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-//     public async Task<ActionResult<Guid>> CreateVehicle([FromBody] CreateVehicleCommand createVehicleCommand)
-//     {
-//         return HandleResult(await Mediator.Send(createVehicleCommand));
-//     }
-//
-//     [HttpPut]
-//     [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-//     public async Task<ActionResult> UpdateVehicle([FromBody] UpdateVehicleCommand updateVehicleCommand)
-//     {
-//         return HandleResult(await Mediator.Send(updateVehicleCommand));
-//     }
-//
-//     [HttpDelete]
-//     [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     public async Task<ActionResult> DeleteVehicle([FromBody] DeleteVehicleCommand deleteVehicleCommand)
-//     {
-//         return HandleResult(await Mediator.Send(deleteVehicleCommand));
-//     }
-//
-//     [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-//     [HttpPost("addImage")]
-//     public async Task<ActionResult> AddImageToVehicle([FromForm] AddImageToVehicleCommand addImageToVehicleCommand)
-//     {
-//         return HandleResult(await Mediator.Send(addImageToVehicleCommand));
-//     }
-//
-//     [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     [HttpDelete("deleteImage")]
-//     public async Task<ActionResult> DeleteImageFromVehicle(
-//         [FromBody] RemoveImageFromVehicleCommand removeImageFromVehicleCommand)
-//     {
-//         return HandleResult(await Mediator.Send(removeImageFromVehicleCommand));
-//     }
-//
-//     [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
-//     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-//     [HttpPost("setMainImage")]
-//     public async Task<ActionResult> SetVehicleMainImage(
-//         [FromBody] SetVehicleMainImageCommand setVehicleMainImageCommand)
-//     {
-//         return HandleResult(await Mediator.Send(setVehicleMainImageCommand));
-//     }
-// }
+namespace LanosCertifiedStore.Presentation.Controllers.VehicleRelated;
+
+public sealed class VehiclesController : BaseModelRelatedApiController
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(PaginationResult<VehicleDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PaginationResult<VehicleDto>>> GetVehicles(
+        [FromQuery] VehicleFilteringRequestParameters requestParameters)
+    {
+        return HandleResult(await Mediator.Send(new VehiclesQueryRequest(requestParameters)));
+    }
+
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(VehicleDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<VehicleDto>> GetVehicle(Guid id)
+    {
+        return HandleResult(await Mediator.Send(new VehicleSingleQueryRequest(id)));
+    }
+
+    [HttpGet("countItems")]
+    [ProducesResponseType(typeof(ItemsCountDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ItemsCountDto>> GetItemsCount(
+        [FromQuery] VehicleFilteringRequestParameters requestParameters)
+    {
+        return HandleResult(await Mediator.Send(new CountVehiclesQueryRequest(requestParameters)));
+    }
+
+    [HttpGet("getPriceRange")]
+    [ProducesResponseType(typeof(Dictionary<string, decimal>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<Dictionary<string, decimal>>> GetPriceRange(
+        [FromQuery] VehicleFilteringRequestParameters requestParameters)
+    {
+        return HandleResult(await Mediator.Send(new VehiclePriceRangeQuery(requestParameters)));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<Guid>> CreateVehicle([FromBody] CreateVehicleCommand createVehicleCommand)
+    {
+        return HandleResult(await Mediator.Send(createVehicleCommand));
+    }
+
+    [HttpPut]
+    [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> UpdateVehicle([FromBody] UpdateVehicleCommand updateVehicleCommand)
+    {
+        return HandleResult(await Mediator.Send(updateVehicleCommand));
+    }
+
+    [HttpDelete]
+    [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> DeleteVehicle([FromBody] DeleteVehicleCommand deleteVehicleCommand)
+    {
+        return HandleResult(await Mediator.Send(deleteVehicleCommand));
+    }
+
+    [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [HttpPost("addImage")]
+    public async Task<ActionResult> AddImageToVehicle([FromForm] AddImageToVehicleCommand addImageToVehicleCommand)
+    {
+        return HandleResult(await Mediator.Send(addImageToVehicleCommand));
+    }
+
+    [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [HttpDelete("deleteImage")]
+    public async Task<ActionResult> DeleteImageFromVehicle(
+        [FromBody] RemoveImageFromVehicleCommand removeImageFromVehicleCommand)
+    {
+        return HandleResult(await Mediator.Send(removeImageFromVehicleCommand));
+    }
+
+    [ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [HttpPost("setMainImage")]
+    public async Task<ActionResult> SetVehicleMainImage(
+        [FromBody] SetVehicleMainImageCommand setVehicleMainImageCommand)
+    {
+        return HandleResult(await Mediator.Send(setVehicleMainImageCommand));
+    }
+}


### PR DESCRIPTION
Implementation of SCRUM-447

we need to make the existing filtering for cars catalog more flexible

# Plan: Flexible Multi-Select Filtering for Vehicle Catalog

## Context

The existing vehicle filtering system uses single-value string-based filters for Brand, Model, Type, and Color properties. This plan implements multi-select GUID-based filtering for all vehicle categorical properties, enabling users to filter by multiple values per filter type (e.g., "BMW OR Audi") while combining different filter types with AND logic (e.g., "Brand IN [BMW, Audi] AND Color IN [Red, Blue]").

**Decisions:**
- Use `List?` for multi-select filter properties (standard mutable collection for DTOs)
- Implement OR logic within filter types via `.Contains()` LINQ expressions (generates SQL IN clauses)
- Keep existing `LowerPriceLimit`/`UpperPriceLimit` decimal range filters unchanged
- Exclude numeric properties (Mileage, ProductionYear, Displacement) per requirements
- Follow VehicleModels pattern for persistence query structure and service layer
- Auto-register VehiclesFilteringCriteriaSelector via existing `IQueryFilteringCriteriaSelector<>` DI pattern
- Use CreatedAt descending as default sorting

## Stack already available (no new deps)

The implementation reuses existing Clean Architecture patterns:
- `BaseFilteringRequestParameters` for pagination and sorting (Application/Shared/RequestParamsRelated)
- `QueryFilteringCriteriaSelectorBase` for converting parameters to LINQ expressions (Persistence/Queries/Common/Classes/SelectorBaseRelated)
- `PredicateBuilder` from LinqKit for combining filter expressions with AND logic
- `CollectionQueryBase` for collection query execution (Persistence/Queries/Common/Classes/QueryBaseRelated/CollectionQueryBase.cs:12-68)
- `CountQueryBase` for count query execution
- MediatR `IRequestHandler` pattern for query handlers
- Existing DI registration in `Persistence/DependencyInjection.cs:27` auto-discovers `IQueryFilteringCriteriaSelector` implementations
- VehicleModelsFilteringCriteriaSelector pattern for single GUID filter (Persistence/Queries/VehicleModelRelated/SelectorRelated/VehicleModelsFilteringCriteriaSelector.cs:9-29)

## Implementation Order

1. Task 1: Update filtering request parameters (Application layer)
2. Task 2: Create filtering criteria selector (Persistence layer) - requires Task 1
3. Task 3: Create sorting settings selector (Persistence layer)
4. Task 4: Create persistence query classes - requires Tasks 2 and 3
5. Task 5: Create vehicle service interface and implementation - requires Task 4
6. Task 6: Register vehicle service in DI - requires Task 5
7. Task 7: Activate query requests and handlers - requires Tasks 5 and 6
8. Task 8: Activate vehicles controller - requires Task 7

## Task 1: Update filtering request parameters to support multi-select GUID-based filtering

**Files:**
- Modify: `src/LanosCertifiedStore.Application/Vehicles/VehicleFilteringRequestParameters.cs`
- Modify: `src/LanosCertifiedStore.Application/Vehicles/IVehicleFilteringRequestParameters.cs`

**Why:** The current filtering uses single-value string-based properties (Brand, Model, Type, Color) which cannot support multi-select filtering or efficient GUID-based lookups. Converting to `List?` enables OR logic within filter types and matches the entity's GUID foreign keys for better query performance.

- [ ] **Step 1: Replace single-value string filters with multi-select GUID collections in VehicleFilteringRequestParameters**

Update the class properties to use `List?` instead of `string?` for all categorical filters, and add the missing vehicle property filters (BodyType, EngineType, TransmissionType, DrivetrainType, Location).

```csharp
public sealed class VehicleFilteringRequestParameters : BaseFilteringRequestParameters,
IVehicleFilteringRequestParameters
{
public List? BrandIds { get; set; }
public List? ModelIds { get; set; }
public List? VehicleTypeIds { get; set; }
public List? ColorIds { get; set; }
public List? BodyTypeIds { get; set; }
public List? EngineTypeIds { get; set; }
public List? TransmissionTypeIds { get; set; }
public List? DrivetrainTypeIds { get; set; }
public List? LocationTownIds { get; set; }
public List? LocationAreaIds { get; set; }
public List? LocationRegionIds { get; set; }
public decimal? LowerPriceLimit { get; set; }
public decimal? UpperPriceLimit { get; set; }
}
```

Key points: Price range filters remain unchanged as they already support range-based filtering.

- [ ] **Step 2: Update interface to match new parameter structure**

Mirror the property changes in the interface so both are synchronized.

```csharp
public interface IVehicleFilteringRequestParameters : IFilteringRequestParameters
{
List? BrandIds { get; set; }
List? ModelIds { get; set; }
List? VehicleTypeIds { get; set; }
List? ColorIds { get; set; }
List? BodyTypeIds { get; set; }
List? EngineTypeIds { get; set; }
List? TransmissionTypeIds { get; set; }
List? DrivetrainTypeIds { get; set; }
List? LocationTownIds { get; set; }
List? LocationAreaIds { get; set; }
List? LocationRegionIds { get; set; }
decimal? LowerPriceLimit { get; set; }
decimal? UpperPriceLimit { get; set; }
}
```

## Task 2: Create filtering criteria selector with OR-within-AND logic

**Files:**
- Create: `src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/SelectorRelated/VehiclesFilteringCriteriaSelector.cs`

**Why:** Without a selector, the filtering request parameters have no mechanism to convert into LINQ query expressions. This selector translates each filter list into an OR expression (vehicle.BrandId IN [guid1, guid2]) and the base class combines them with AND logic between different filter types.

- [ ] **Step 1: Create VehiclesFilteringCriteriaSelector with multi-select filter aspect mappings**

Create the selector class that inherits from QueryFilteringCriteriaSelectorBase and implements the GetAspectMappings method. Each aspect checks if the filter list has values, then generates a `.Contains()` expression for OR logic within that filter type.

```csharp
using System.Linq.Expressions;
using LanosCertifiedStore.Application.Shared.RequestParamsRelated;
using LanosCertifiedStore.Application.Vehicles;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;
using LanosCertifiedStore.Persistence.Queries.Common.Classes.SelectorBaseRelated;

namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.SelectorRelated;

internal sealed class VehiclesFilteringCriteriaSelector : QueryFilteringCriteriaSelectorBase
{
private protected override IReadOnlyCollection> Expression)>
GetAspectMappings(IFilteringRequestParameters filteringRequestParameters)
{
var parameters = (filteringRequestParameters as IVehicleFilteringRequestParameters)!;

return
[
(
IsValidFilterList(parameters.BrandIds),
vehicle => parameters.BrandIds!.Contains(vehicle.BrandId)
),
(
IsValidFilterList(parameters.ModelIds),
vehicle => parameters.ModelIds!.Contains(vehicle.ModelId)
),
(
IsValidFilterList(parameters.VehicleTypeIds),
vehicle => parameters.VehicleTypeIds!.Contains(vehicle.VehicleTypeId)
),
(
IsValidFilterList(parameters.ColorIds),
vehicle => parameters.ColorIds!.Contains(vehicle.ColorId)
),
(
IsValidFilterList(parameters.BodyTypeIds),
vehicle => parameters.BodyTypeIds!.Contains(vehicle.BodyTypeId)
),
(
IsValidFilterList(parameters.EngineTypeIds),
vehicle => parameters.EngineTypeIds!.Contains(vehicle.EngineTypeId)
),
(
IsValidFilterList(parameters.TransmissionTypeIds),
vehicle => parameters.TransmissionTypeIds!.Contains(vehicle.TransmissionTypeId)
),
(
IsValidFilterList(parameters.DrivetrainTypeIds),
vehicle => parameters.DrivetrainTypeIds!.Contains(vehicle.DrivetrainTypeId)
),
(
IsValidFilterList(parameters.LocationTownIds),
vehicle => parameters.LocationTownIds!.Contains(vehicle.LocationTownId)
),
(
IsValidFilterList(parameters.LocationAreaIds),
vehicle => parameters.LocationAreaIds!.Contains(vehicle.LocationAreaId)
),
(
IsValidFilterList(parameters.LocationRegionIds),
vehicle => parameters.LocationRegionIds!.Contains(vehicle.LocationRegionId)
),
(
parameters.LowerPriceLimit.HasValue,
vehicle => vehicle.Prices.Any(p => p.PriceValue >= parameters.LowerPriceLimit!.Value)
),
(
parameters.UpperPriceLimit.HasValue,
vehicle => vehicle.Prices.Any(p => p.PriceValue ? filterList)
{
return filterList is { Count: > 0 };
}
}
```

Key points: The `Contains()` method generates SQL `IN` clauses for efficient filtering. Null or empty filter lists are skipped (IsValid = false). Price filters use `Any()` to match the collection navigation property structure.

## Task 3: Create sorting settings selector for vehicles

**Files:**
- Create: `src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/SelectorRelated/VehiclesSortingSettingsSelector.cs`

**Why:** The query execution pipeline requires a sorting selector to order results. Following the existing pattern from other entities, vehicles should sort by CreatedAt descending by default to show newest listings first.

- [ ] **Step 1: Create VehiclesSortingSettingsSelector with CreatedAt descending default**

Create the sorting selector that returns the sort expression and direction.

```csharp
using System.Linq.Expressions;
using LanosCertifiedStore.Application.Shared.RequestParamsRelated;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;
using LanosCertifiedStore.Persistence.Queries.Common.Contracts;

namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.SelectorRelated;

internal sealed class VehiclesSortingSettingsSelector : IQuerySortingSettingsSelector
{
public (Expression> SortingSettings, bool IsAscending) GetSortingSettings(
IFilteringRequestParameters filteringRequestParameters)
{
return (vehicle => vehicle.CreatedAt, false);
}
}
```

Key points: Returns tuple with sorting expression and direction (false = descending). Future enhancement could support dynamic sorting based on request parameters.

## Task 4: Create persistence query classes for vehicle collection and count operations

**Files:**
- Create: `src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/Common/CollectionVehiclesQueryBase.cs`
- Create: `src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/CollectionVehiclesQuery.cs`
- Create: `src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/CountVehiclesQuery.cs`
- Create: `src/LanosCertifiedStore.Persistence/Queries/VehicleRelated/QueryRelated/SingleVehicleQuery.cs`

**Why:** The persistence layer needs concrete query classes to execute database operations. Following the VehicleModels pattern (Persistence/Queries/VehicleModelRelated/QueryRelated), these classes inject the filtering and sorting selectors to build and execute filtered, sorted, paginated queries.

- [ ] **Step 1: Create CollectionVehiclesQueryBase abstract class**

Create the base query class that orchestrates filtering, sorting, pagination, and projection for vehicle collections.

```csharp
using AutoMapper;
using LanosCertifiedStore.Application.Shared.RequestRelated.QueryRelated;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;
using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
using LanosCertifiedStore.Persistence.Queries.Common.Classes.QueryBaseRelated;
using LanosCertifiedStore.Persistence.Queries.Common.Contracts;

namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated.Common;

public abstract class CollectionVehiclesQueryBase(
ApplicationDatabaseContext context,
IQueryFilteringCriteriaSelector filteringCriteriaSelector,
IQuerySortingSettingsSelector sortingSettingsSelector,
IQueryPaginator queryPaginator,
IMapper mapper) : CollectionQueryBase
where TDto : class
{
public sealed override async Task> Execute(
IQueryRequest queryRequest, CancellationToken cancellationToken)
{
var queryable = GetDatabaseQueryable(context);

queryable = GetFilteredQueryable(queryRequest, queryable, filteringCriteriaSelector);
queryable = GetSortedQueryable(queryRequest, queryable, sortingSettingsSelector);
queryable = GetPaginatedQueryable(queryRequest, queryable, queryPaginator);

var executionResult = await GetQueryResult(queryable, mapper, cancellationToken);

return executionResult;
}
}
```

Key points: Mirrors VehicleModels pattern exactly. Sealed override prevents further customization in derived classes.

- [ ] **Step 2: Create CollectionVehiclesQuery concrete implementation**

Create the concrete query class that will be injected into the service layer.

```csharp
using AutoMapper;
using LanosCertifiedStore.Application.Vehicles.Dtos;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;
using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
using LanosCertifiedStore.Persistence.Queries.Common.Contracts;
using LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated.Common;

namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;

public sealed class CollectionVehiclesQuery(
ApplicationDatabaseContext context,
IQueryFilteringCriteriaSelector filteringCriteriaSelector,
IQuerySortingSettingsSelector sortingSettingsSelector,
IQueryPaginator queryPaginator,
IMapper mapper) : CollectionVehiclesQueryBase(
context,
filteringCriteriaSelector,
sortingSettingsSelector,
queryPaginator,
mapper);
```

Key points: Primary constructor syntax passes all dependencies to base. Auto-registered as `CollectionVehiclesQuery` by Persistence/DependencyInjection.cs:69.

- [ ] **Step 3: Create CountVehiclesQuery for item count operations**

Create the count query class for returning filtered vehicle counts (used for pagination metadata).

```csharp
using LanosCertifiedStore.Application.Shared.DtosRelated;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;
using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
using LanosCertifiedStore.Persistence.Queries.Common.Classes.QueryBaseRelated;
using LanosCertifiedStore.Persistence.Queries.Common.Contracts;

namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;

public sealed class CountVehiclesQuery(
ApplicationDatabaseContext context,
IQueryFilteringCriteriaSelector filteringCriteriaSelector) : CountQueryBase
{
public override async Task Execute(
IQueryRequest queryRequest,
CancellationToken cancellationToken)
{
var queryable = GetDatabaseQueryable(context);

queryable = GetFilteredQueryable(queryRequest, queryable, filteringCriteriaSelector);

var count = await GetItemsCount(queryable, cancellationToken);

return new ItemsCountDto { Count = count };
}
}
```

Key points: Count queries only need filtering (no sorting or pagination). Inherits from CountQueryBase.

- [ ] **Step 4: Create SingleVehicleQuery for retrieving individual vehicles**

Create the single-item query for GetVehicle(id) endpoint.

```csharp
using AutoMapper;
using LanosCertifiedStore.Application.Vehicles.Dtos;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;
using LanosCertifiedStore.Persistence.Contexts.ApplicationDatabaseContext;
using LanosCertifiedStore.Persistence.Queries.Common.Classes.QueryBaseRelated;

namespace LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;

public sealed class SingleVehicleQuery(
ApplicationDatabaseContext context,
IMapper mapper) : SingleQueryBase(context, mapper);
```

Key points: Minimal implementation; all logic in SingleQueryBase.

## Task 5: Create vehicle service interface and implementation

**Files:**
- Create: `src/LanosCertifiedStore.Application/Vehicles/IVehicleService.cs`
- Create: `src/LanosCertifiedStore.Infrastructure/Vehicles/VehicleService.cs`

**Why:** The Application layer query handlers need a service abstraction to execute persistence queries. Following the VehicleModelService pattern (Infrastructure/Vehicles/VehicleModelService.cs:16-71), the service acts as a facade over the persistence query classes.

- [ ] **Step 1: Create IVehicleService interface with query operation contracts**

Define the service interface in the Application layer for collection, single, and count queries.

```csharp
using LanosCertifiedStore.Application.Shared.DtosRelated;
using LanosCertifiedStore.Application.Vehicles.Dtos;
using LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
using LanosCertifiedStore.Application.Vehicles.Queries.VehicleDetailsQueryRelated;
using LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;

namespace LanosCertifiedStore.Application.Vehicles;

public interface IVehicleService
{
Task> GetVehicleCollection(
VehiclesQueryRequest queryRequest,
CancellationToken cancellationToken);

Task GetSingleVehicle(
VehicleSingleQueryRequest queryRequest,
CancellationToken cancellationToken);

Task GetVehiclesCount(
CountVehiclesQueryRequest queryRequest,
CancellationToken cancellationToken);
}
```

- [ ] **Step 2: Implement VehicleService with persistence query delegation**

Create the concrete implementation that injects and delegates to persistence query classes.

```csharp
using LanosCertifiedStore.Application.Shared.DtosRelated;
using LanosCertifiedStore.Application.Vehicles;
using LanosCertifiedStore.Application.Vehicles.Dtos;
using LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
using LanosCertifiedStore.Application.Vehicles.Queries.VehicleDetailsQueryRelated;
using LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
using LanosCertifiedStore.Persistence.Queries.VehicleRelated.QueryRelated;

namespace LanosCertifiedStore.Infrastructure.Vehicles;

internal sealed class VehicleService(
CollectionVehiclesQuery collectionVehiclesQuery,
SingleVehicleQuery singleVehicleQuery,
CountVehiclesQuery countVehiclesQuery) : IVehicleService
{
public async Task> GetVehicleCollection(
VehiclesQueryRequest queryRequest,
CancellationToken cancellationToken)
{
return await collectionVehiclesQuery.Execute(queryRequest, cancellationToken);
}

public async Task GetSingleVehicle(
VehicleSingleQueryRequest queryRequest,
CancellationToken cancellationToken)
{
return await singleVehicleQuery.Execute(queryRequest, cancellationToken);
}

public async Task GetVehiclesCount(
CountVehiclesQueryRequest queryRequest,
CancellationToken cancellationToken)
{
return await countVehiclesQuery.Execute(queryRequest, cancellationToken);
}
}
```

Key points: Uses primary constructor for dependency injection. Methods are simple pass-through delegations to persistence queries.

## Task 6: Register vehicle service in dependency injection

**Files:**
- Modify: `src/LanosCertifiedStore.Infrastructure/DependencyInjection.cs`

**Why:** IVehicleService must be registered in the DI container for injection into query handlers. The service registration pattern at Infrastructure/DependencyInjection.cs:85-90 groups vehicle-related services together.

- [ ] **Step 1: Add IVehicleService registration to AddVehicleRelatedServices method**

Add the service registration alongside existing vehicle services (VehicleBrand, VehicleColor, VehicleModel).

```csharp
private static void AddVehicleRelatedServices(IServiceCollection services)
{
services.AddScoped();
services.AddScoped();
services.AddScoped();
services.AddScoped();
}
```

Imports: Add `using LanosCertifiedStore.Application.Vehicles;` at the top of the file.

## Task 7: Activate query requests and handlers by uncommenting and updating implementations

**Files:**
- Modify: `src/LanosCertifiedStore.Application/Vehicles/Queries/VehiclesQueryRelated/VehiclesQueryRequest.cs`
- Modify: `src/LanosCertifiedStore.Application/Vehicles/Queries/VehiclesQueryRelated/VehiclesQueryHandler.cs`
- Modify: `src/LanosCertifiedStore.Application/Vehicles/Queries/CountVehiclesQueryRelated/CountVehiclesQueryRequest.cs`
- Modify: `src/LanosCertifiedStore.Application/Vehicles/Queries/CountVehiclesQueryRelated/CountVehiclesQueryHandler.cs`

**Why:** These files are currently commented out (Application/Vehicles/Queries/VehiclesQueryRelated/VehiclesQueryHandler.cs:3-11). They need to be activated and updated to use the new IVehicleService instead of the non-existent CollectionQueryHandlerBase base class referenced in the TODO comment.

- [ ] **Step 1: Activate VehiclesQueryRequest with proper interface implementation**

Uncomment the VehiclesQueryRequest and update to use the correct interface and parameter type.

```csharp
using LanosCertifiedStore.Application.Shared.RequestRelated.QueryRelated;
using LanosCertifiedStore.Application.Shared.ResultRelated;
using LanosCertifiedStore.Application.Vehicles.Dtos;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;

namespace LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;

public sealed record VehiclesQueryRequest(
IVehicleFilteringRequestParameters FilteringParameters) :
ICollectionQueryRequest, VehicleDto>;
```

Key points: Changed from IVehicleFilteringRequestParameters to use the interface directly. Removed IsTracked parameter as it's not used in the query pattern.

- [ ] **Step 2: Activate VehiclesQueryHandler with IVehicleService delegation**

Replace the commented TODO implementation with a working handler that uses IVehicleService.

```csharp
using LanosCertifiedStore.Application.Shared.ResultRelated;
using LanosCertifiedStore.Application.Vehicles.Dtos;
using MediatR;

namespace LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;

internal sealed class VehiclesQueryHandler(IVehicleService vehicleService) :
IRequestHandler>>
{
public async Task>> Handle(
VehiclesQueryRequest request, CancellationToken cancellationToken)
{
var vehicles = await vehicleService.GetVehicleCollection(request, cancellationToken);

var paginationResult = new PaginationResult(vehicles, request.FilteringParameters.PageIndex);

return paginationResult;
}
}
```

Imports: Add `using LanosCertifiedStore.Application.Vehicles;` for IVehicleService.

- [ ] **Step 3: Activate CountVehiclesQueryRequest**

Uncomment and ensure the request record is properly defined.

```csharp
using LanosCertifiedStore.Application.Shared.DtosRelated;
using LanosCertifiedStore.Application.Shared.RequestRelated.QueryRelated;
using LanosCertifiedStore.Application.Shared.ResultRelated;
using LanosCertifiedStore.Domain.Entities.VehicleRelated;
using MediatR;

namespace LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;

public sealed record CountVehiclesQueryRequest(
IVehicleFilteringRequestParameters FilteringParameters) :
ICountQueryRequest, IRequest>;
```

- [ ] **Step 4: Activate CountVehiclesQueryHandler with IVehicleService delegation**

Replace the commented TODO implementation with a working count handler.

```csharp
using LanosCertifiedStore.Application.Shared.DtosRelated;
using LanosCertifiedStore.Application.Shared.ResultRelated;
using MediatR;

namespace LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;

internal sealed class CountVehiclesQueryHandler(IVehicleService vehicleService) :
IRequestHandler>
{
public async Task> Handle(
CountVehiclesQueryRequest request, CancellationToken cancellationToken)
{
var count = await vehicleService.GetVehiclesCount(request, cancellationToken);

return count;
}
}
```

Imports: Add `using LanosCertifiedStore.Application.Vehicles;` for IVehicleService.

## Task 8: Activate vehicles controller for API exposure

**Files:**
- Modify: `src/LanosCertifiedStore.Presentation/Controllers/VehicleRelated/VehiclesController.cs`

**Why:** The controller is entirely commented out (Presentation/Controllers/VehicleRelated/VehiclesController.cs:3-95). Uncommenting it exposes the filtering API endpoints (/api/vehicles with query parameters) so the multi-select filtering becomes accessible via HTTP.

- [ ] **Step 1: Uncomment the entire VehiclesController class**

Remove the comment markers from the entire controller class (lines 3-95). Update the query request instantiation to use the new parameter type.

```csharp
using LanosCertifiedStore.Application.Shared.DtosRelated;
using LanosCertifiedStore.Application.Shared.ResultRelated;
using LanosCertifiedStore.Application.Vehicles;
using LanosCertifiedStore.Application.Vehicles.Commands.CreateVehicleRelated;
using LanosCertifiedStore.Application.Vehicles.Commands.DeleteVehicleRelated;
using LanosCertifiedStore.Application.Vehicles.Commands.UpdateVehicleRelated;
using LanosCertifiedStore.Application.Vehicles.Dtos;
using LanosCertifiedStore.Application.Vehicles.Queries.CountVehiclesQueryRelated;
using LanosCertifiedStore.Application.Vehicles.Queries.VehicleDetailsQueryRelated;
using LanosCertifiedStore.Application.Vehicles.Queries.VehiclePriceRangeQueryRelated;
using LanosCertifiedStore.Application.Vehicles.Queries.VehiclesQueryRelated;
using LanosCertifiedStore.Presentation.Controllers.Common;
using LanosCertifiedStore.Presentation.Contracts;
using MediatR;
using Microsoft.AspNetCore.Http;
using Microsoft.AspNetCore.Mvc;

namespace LanosCertifiedStore.Presentation.Controllers.VehicleRelated;

public sealed class VehiclesController : BaseModelRelatedApiController
{
[HttpGet]
[ProducesResponseType(typeof(PaginationResult), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
public async Task>> GetVehicles(
[FromQuery] VehicleFilteringRequestParameters requestParameters)
{
return HandleResult(await Mediator.Send(new VehiclesQueryRequest(requestParameters)));
}

[HttpGet("{id:guid}")]
[ProducesResponseType(typeof(VehicleDto), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
public async Task> GetVehicle(Guid id)
{
return HandleResult(await Mediator.Send(new VehicleSingleQueryRequest(id)));
}

[HttpGet("countItems")]
[ProducesResponseType(typeof(ItemsCountDto), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
public async Task> GetItemsCount(
[FromQuery] VehicleFilteringRequestParameters requestParameters)
{
return HandleResult(await Mediator.Send(new CountVehiclesQueryRequest(requestParameters)));
}

[HttpGet("getPriceRange")]
[ProducesResponseType(typeof(Dictionary), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
public async Task>> GetPriceRange(
[FromQuery] VehicleFilteringRequestParameters requestParameters)
{
return HandleResult(await Mediator.Send(new VehiclePriceRangeQuery(requestParameters)));
}

[HttpPost]
[ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
public async Task> CreateVehicle([FromBody] CreateVehicleCommand createVehicleCommand)
{
return HandleResult(await Mediator.Send(createVehicleCommand));
}

[HttpPut]
[ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
public async Task UpdateVehicle([FromBody] UpdateVehicleCommand updateVehicleCommand)
{
return HandleResult(await Mediator.Send(updateVehicleCommand));
}

[HttpDelete]
[ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
public async Task DeleteVehicle([FromBody] DeleteVehicleCommand deleteVehicleCommand)
{
return HandleResult(await Mediator.Send(deleteVehicleCommand));
}

[ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
[HttpPost("addImage")]
public async Task AddImageToVehicle([FromForm] AddImageToVehicleCommand addImageToVehicleCommand)
{
return HandleResult(await Mediator.Send(addImageToVehicleCommand));
}

[ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
[HttpDelete("deleteImage")]
public async Task DeleteImageFromVehicle(
[FromBody] RemoveImageFromVehicleCommand removeImageFromVehicleCommand)
{
return HandleResult(await Mediator.Send(removeImageFromVehicleCommand));
}

[ProducesResponseType(typeof(Unit), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
[HttpPost("setMainImage")]
public async Task SetVehicleMainImage(
[FromBody] SetVehicleMainImageCommand setVehicleMainImageCommand)
{
return HandleResult(await Mediator.Send(setVehicleMainImageCommand));
}
}
```

Key points: ASP.NET Core automatically binds `List?` from query strings like `?brandIds=guid1&brandIds=guid2`. The [FromQuery] attribute handles the collection binding. All query request instantiations now pass the updated parameter types.